### PR TITLE
Fixed columns on info page with column span

### DIFF
--- a/ui/src/pages/PodcastInfoPage.tsx
+++ b/ui/src/pages/PodcastInfoPage.tsx
@@ -149,7 +149,7 @@ export const PodcastInfoPage = () => {
                 }]
             }}/>}/>
 
-            <div className="col-span-2">
+            <div className="col-span-1 sm:col-span-2">
             <SysCard title={t('podfetch-status')}>
                 <div className="grid grid-cols-2 text-white gap-4">
                     <div className="text-xl">{t('podindex-configured')}</div>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

On the info page, there are always two columns of cards, no matter how small the screen is.

To solve this, there must not be a card that has a column span of 2. So I added an `sm:` modifier to shrink the size of the card to one column on small devices.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
