### PR TITLE
Fixed SQL query for podcast search

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -822,7 +822,13 @@ impl DB {
                            latest_pub: bool) ->Vec<Podcast>{
         let returned_podcasts: Vec<Podcast>;
         if latest_pub && title.is_none() && !order_desc {
-            returned_podcasts = sql_query("SELECT * FROM podcasts,podcast_episodes WHERE podcasts.id=podcast_episodes.podcast_id GROUP BY podcasts.id ORDER BY podcast_episodes.date_of_recording DESC")
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts, podcast_episodes
+                WHERE    podcasts.id = podcast_episodes.podcast_id
+                GROUP BY podcasts.id
+                ORDER BY MAX(podcast_episodes.date_of_recording) DESC
+                ")
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         } else if latest_pub && title.is_some() && !order_desc {
@@ -838,26 +844,42 @@ impl DB {
                 .expect("Error loading podcasts");
         }
         else if latest_pub && title.is_none() && order_desc {
-            returned_podcasts = sql_query("SELECT * FROM podcasts,podcast_episodes WHERE podcasts\
-            .id=podcast_episodes.podcast_id GROUP BY podcasts.id ORDER BY podcast_episodes\
-            .date_of_recording,podcasts.name DESC")
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts, podcast_episodes
+                WHERE    podcasts.id = podcast_episodes.podcast_id
+                GROUP BY podcasts.id
+                ORDER BY MAX(podcast_episodes.date_of_recording), podcasts.name DESC
+                ")
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         }
         else if !latest_pub && title.is_none() && !order_desc {
-            returned_podcasts = sql_query("SELECT * FROM podcasts ORDER BY podcasts.name")
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts
+                ORDER BY podcasts.name
+                ")
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         }
         else if !latest_pub && title.is_none() && order_desc {
-            returned_podcasts = sql_query("SELECT * FROM podcasts ORDER BY podcasts.name DESC")
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts
+                ORDER BY podcasts.name DESC
+                ")
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         }
         else{
             // only left possibility 010
-            returned_podcasts = sql_query("SELECT * FROM podcasts WHERE podcasts.name LIKE CONCAT\
-            ('%',?,'%') ORDER BY podcasts.name ASC")
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts
+                WHERE    LOWER(podcasts.name) LIKE '%' || LOWER(?)  ||'%' 
+                ORDER BY podcasts.name ASC
+                ")
                 .bind::<Text, _>(title.unwrap())
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");

--- a/src/db.rs
+++ b/src/db.rs
@@ -826,9 +826,16 @@ impl DB {
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         } else if latest_pub && title.is_some() && !order_desc {
-            returned_podcasts = sql_query("SELECT * FROM podcasts,podcast_episodes WHERE podcasts\
-            .id=podcast_episodes.podcast_id AND LOWER(podcasts.name) LIKE '%'+LOWER(?)+'%' ORDER \
-            BY podcast_episodes.date_of_recording DESC")
+
+            println!("Foo!!!");
+
+            returned_podcasts = sql_query(r"
+                SELECT   *
+                FROM     podcasts, podcast_episodes
+                WHERE    podcasts.id = podcast_episodes.podcast_id AND LOWER(podcasts.name) LIKE '%' || LOWER(?) || '%'
+                GROUP BY podcasts.id
+                ORDER BY MAX(podcast_episodes.date_of_recording) DESC
+                ")
                 .bind::<Text,_>(title.unwrap())
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");

--- a/src/db.rs
+++ b/src/db.rs
@@ -826,9 +826,6 @@ impl DB {
                 .load::<Podcast>(conn)
                 .expect("Error loading podcasts");
         } else if latest_pub && title.is_some() && !order_desc {
-
-            println!("Foo!!!");
-
             returned_podcasts = sql_query(r"
                 SELECT   *
                 FROM     podcasts, podcast_episodes


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I fixed the query for searching for podcasts by replacing `+` with `||` which is the SQLite operator for concatenating strings.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
