### PR TITLE
Fix incorrect description for OIDC_REDIRECT_URI and clean table in auth documentation

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -25,3 +25,5 @@ If you enable it you need to disable BASIC_AUTH as it is not possible to use bot
 | OIDC_REDIRECT_URI | The URI the OIDC authority redirects to after authentication. | `<your-server-url>/ui/login`                                 |
 | OIDC_SCOPE        | The scope of the oidc token                                   | `openid profile email`                                       |
 | OIDC_JWKS         | The JWKS token uri                                            | `<keycloak-url>/realms/master/protocol/openid-connect/certs` |
+
+Note: For OIDC authorities that allow for selecting between `Confidential`/`Private` and `Public` for the Client Type (for example Authentik), use `Public`, as PodFetch does not need a client secret.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -17,11 +17,11 @@ PodFetch also supports OIDC authentication. If you want to use it you need to se
 
 If you enable it you need to disable BASIC_AUTH as it is not possible to use both at the same time.
 
-| Variable          | Description                           | example                                                         |
-|-------------------|---------------------------------------|-----------------------------------------------------------------|
-| OIDC_AUTH         | Flag if OIDC should be enabled        | true                                                            |
-| OIDC_AUTHORITY    | The url of the OIDC authority.        | Keycloak Master <keycloak-url/realms/master                     |
-| OIDC_CLIENT_ID    | The client id of the OIDC client.     | podfetch                                                        |
-| OIDC_REDIRECT_URI | The client secret of the OIDC client. | <your-server-url>/ui/login                                      |
-| OIDC_SCOPE        | The scope of the oidc token           | This has a default value of "openid profile email"              |
-| OIDC_JWKS         | The JWKS token uri                    | For Keycloak it is /realms/master/protocol/openid-connect/certs |       
+| Variable          | Description                                                   | Example                                                      |
+|-------------------|---------------------------------------------------------------|--------------------------------------------------------------|
+| OIDC_AUTH         | Flag if OIDC should be enabled                                | `true`                                                       |
+| OIDC_AUTHORITY    | The url of the OIDC authority.                                | `<keycloak-url>/realms/master`                               |
+| OIDC_CLIENT_ID    | The client id of the OIDC client.                             | `podfetch`                                                   |
+| OIDC_REDIRECT_URI | The URI the OIDC authority redirects to after authentication. | `<your-server-url>/ui/login`                                 |
+| OIDC_SCOPE        | The scope of the oidc token                                   | `openid profile email`                                       |
+| OIDC_JWKS         | The JWKS token uri                                            | `<keycloak-url>/realms/master/protocol/openid-connect/certs` |


### PR DESCRIPTION
### Description

- Fixed the description for what `OIDC_REDIRECT_URI` environment variable does in the authentication documentation for the docker container
- Cleaned up the table a bit to have consistency in how it's presented, as well as fixing the triangular-bracketed areas since they ended up rendered invisible

### Linked Issues

n/a

### Additional context

I don't know if you want to add this information anywhere, but specifically for Authentik as the OIDC authority, `Client type` in the provider for PodFetch **must** be set to `Public` since PodFetch doesn't do anything with a client secret (at least from my quick skim through the source code, it seems that way).
