### PR TITLE
Added missing English translation for delete-podcast-without-files-body

### DIFF
--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -71,6 +71,7 @@
   "delete-podcast": "Delete podcast",
   "cancel": "Cancel",
   "delete-podcast-with-files-body": "Are you sure you want to delete the podcast {{name}} and all downloaded files?",
+  "delete-podcast-without-files-body": "Are you sure you want to delete the podcast {{name}}?",
   "podcast-deleted": "Podcast deleted",
   "manage-podcasts": "Manage podcasts",
   "delete-podcasts-without-files": "Delete podcasts without files",

--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -71,7 +71,7 @@
   "delete-podcast": "Delete podcast",
   "cancel": "Cancel",
   "delete-podcast-with-files-body": "Are you sure you want to delete the podcast {{name}} and all downloaded files?",
-  "delete-podcast-without-files-body": "Are you sure you want to delete the podcast {{name}}?",
+  "delete-podcast-without-files-body": "Are you sure you want to delete the podcast {{name}}? No files will be deleted",
   "podcast-deleted": "Podcast deleted",
   "manage-podcasts": "Manage podcasts",
   "delete-podcasts-without-files": "Delete podcasts without files",


### PR DESCRIPTION
### Description

The translation was missing for this translation string, so it was explicitly showing `delete-podcast-without-files-body` instead of actual text
