### PR TITLE
Fixed incorrect button label for deleting podcast with files

### DIFF
--- a/ui/src/components/PodcastDelete.tsx
+++ b/ui/src/components/PodcastDelete.tsx
@@ -50,7 +50,7 @@ export const PodcastDelete = () => {
                                     bodyText: t('delete-podcast-with-files-body', {name: p.name})
                                 }))
                                 dispatch(setModalOpen(true))
-                            }}>{t('delete-podcasts-without-files')}</button>
+                            }}>{t('delete-podcasts-with-files')}</button>
                             <button className="p-2 bg-red-500" onClick={()=>{
                                 dispatch(setConfirmModalData({
                                     headerText: t('delete-podcast-without-files'),


### PR DESCRIPTION
### Description

The button that triggers deleting podcasts _with_ files had the label for deleting podcasts _without_ files, so both buttons had the same label. This fixes it to give deleting podcasts _with_ files the correct button label.
