### PR TITLE
Change the docker default to non dev branch for postgres image

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ volumes:
 version: '3'
 services:
   podfetch:
-    image: samuel19982/podfetch:dev-postgres
+    image: samuel19982/podfetch:postgres
     user: ${UID:-1000}:${GID:-1000}
     ports:
       - "80:8000"

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   podfetch:
-    image: samuel19982/podfetch:dev-postgres
+    image: samuel19982/podfetch:postgres
     user: ${UID:-1000}:${GID:-1000}
     ports:
       - "80:8000"


### PR DESCRIPTION
Change the default to non dev branch for postgres image

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The dev branch seems to track different things. so it seems reasonable to switch to the postgres tag