### PR TITLE
Added User Creation Section & Updated GPodder API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Hosting options are described here: [HOSTING.md](docs/HOSTING.md)
 
 The cli usage is described here: [CLI.md](docs/CLI.md)
 
+# User creation
+
+You can create an admin, user, or uploader either through [CLI](docs/CLI.md) or via invites.
+
+To generate an invite, log into Podfetch → Top Right Icon → User Administration → Invites
+
 # Environment Variables
 
 | Variable         | Description                                   | Default                  |
@@ -161,16 +167,18 @@ To configure it you need to create an account on that website. After creating an
 
 After successful setup you should see on the settings page a green checkmark next to the Podindex config section.
 
-# GPodder
+# GPodder API
 
-Podfetch also supports the GPodder api. You can use your current GPodder account to login to Podfetch and continue using your current podcast app.
-To do that just go to the settings page and enter your GPodder username and password.
+Podfetch supports the [GPodder API](https://gpoddernet.readthedocs.io/en/latest/api/index.html).
 
-To enable it you need to set the following environment variables:
+You need to set the following environment variable to `true` to enable it:
 | Variable            | Description                           | Default |
 |---------------------|---------------------------------------|---------|
-| GPODDER_INTEGRATION_ENABLED    | Activates the GPodder integration via your server url  | false|
+| GPODDER_INTEGRATION_ENABLED    | Activates the GPodder integration via your `SERVER_URL` | false|
 
+You will also need to set up [`BASIC_AUTH` or `OIDC_AUTH`](docs/AUTH.md) and [create a user](#user-creation).
+
+You can use your new user account to log into podcast apps that supports the GPodder API by using your `SERVER_URL` and login information.
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ After successful setup you should see on the settings page a green checkmark nex
 
 Podfetch supports the [GPodder API](https://gpoddernet.readthedocs.io/en/latest/api/index.html).
 
-You need to set the following environment variable to `true` to enable it:
+The following environment variable must be set to `true` to enable it:
 | Variable            | Description                           | Default |
 |---------------------|---------------------------------------|---------|
 | GPODDER_INTEGRATION_ENABLED    | Activates the GPodder integration via your `SERVER_URL` | false|

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,16 +1,18 @@
 # CLI usage
 
-The CLI can be used to update, remove, list registered users in PodFetch. You can get help anytime by typing --help/help
+The CLI can be used to create and manage users, and also to refresh and list podcasts.
+
+You can get help anytime by typing `--help` or `help`.
 
 # Usage
 
-# Get general help
+## Get general help
 
 ```bash
 podfetch --help
 ```
 
-# Get help for a specific command
+## Get help for a specific command
 
 ```bash
 podfetch <command> --help
@@ -20,12 +22,13 @@ e.g.
 
 ```bash
 podfetch users --help
+podfetch podcasts --help
 ```
 
 
-# Usage in docker
+## Usage in docker
 
 ```bash
-docker ps #This will get you the id of the
+docker ps #This will help obtain your PodFetch container's name
 docker exec -it <your-docker-id/name> /app/podfetch <your-command> # Will execute your desired command in the container
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When enabling `GPODDER_INTEGRATION_ENABLED` without setting up AUTH, you get the below error:

```
GPODDER_INTEGRATION_ENABLED activated but no BASIC_AUTH or OIDC_AUTH set. Please set BASIC_AUTH or OIDC_AUTH in the .env file.

Debug file located at /home/rust/src/target/x86_64-unknown-linux-musl/release/build/podfetch-47ad4ae1dbcbace8/out/built.rs
```

Created a **User Creation** section to assist with the updated **GPodder API** section, as there is no mentions about invites.

**GPodder API** section now has more clarity on what is needed to set up GPodder API access.