### PR TITLE
221 delete single podcast episodes not all episodes from a specific podcast

### DIFF
--- a/migrations/postgres/2023-08-01-165632_delete-flag-episodes/down.sql
+++ b/migrations/postgres/2023-08-01-165632_delete-flag-episodes/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE podcast_episodes DROP COLUMN  deleted;

--- a/migrations/postgres/2023-08-01-165632_delete-flag-episodes/up.sql
+++ b/migrations/postgres/2023-08-01-165632_delete-flag-episodes/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE podcast_episodes ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sqlite/2023-08-01-165632_delete-flag-episodes/down.sql
+++ b/migrations/sqlite/2023-08-01-165632_delete-flag-episodes/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE podcast_episodes DROP COLUMN  deleted;

--- a/migrations/sqlite/2023-08-01-165632_delete-flag-episodes/up.sql
+++ b/migrations/sqlite/2023-08-01-165632_delete-flag-episodes/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE podcast_episodes ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/constants/inner_constants.rs
+++ b/src/constants/inner_constants.rs
@@ -9,6 +9,7 @@ pub enum PodcastType {
     AddPodcast,
     AddPodcastEpisode,
     AddPodcastEpisodes,
+    DeletePodcastEpisode,
     RefreshPodcast,
     OpmlAdded,
     OpmlErrored

--- a/src/controllers/podcast_episode_controller.rs
+++ b/src/controllers/podcast_episode_controller.rs
@@ -1,17 +1,21 @@
 use crate::service::mapping_service::MappingService;
 use crate::service::podcast_episode_service::PodcastEpisodeService;
 use actix_web::web::{Data, Query};
-use actix_web::{get, put};
+use actix_web::{delete, get, put};
 use actix_web::{web, HttpResponse};
 use serde_json::from_str;
 use std::sync::Mutex;
 use std::thread;
+use actix::Addr;
+use crate::constants::inner_constants::PodcastType;
 use crate::db::TimelineItem;
 use crate::DbPool;
 use crate::models::favorites::Favorite;
+use crate::models::messages::BroadcastMessage;
 use crate::models::podcast_episode::PodcastEpisode;
 use crate::models::podcasts::Podcast;
 use crate::models::user::User;
+use crate::models::web_socket_message::Lobby;
 use crate::mutex::LockResultExt;
 use crate::utils::error::CustomError;
 
@@ -136,3 +140,37 @@ pub async fn download_podcast_episodes_of_podcast(id: web::Path<String>, conn: D
 
     Ok(HttpResponse::Ok().json("Download started"))
 }
+
+/**
+ * id is the episode id (uuid)
+ */
+#[utoipa::path(
+context_path = "/api/v1",
+responses(
+(status = 204, description = "Starts the download of a given podcast episode")),
+tag = "podcast_episodes"
+)]
+#[delete("/episodes/{id}/download")]
+pub async fn delete_podcast_episode_locally(id: web::Path<String>,
+                                            requester: Option<web::ReqData<User>>, db:
+                                            Data<DbPool>, lobby: Data<Addr<Lobby>>)
+    ->  Result<HttpResponse, CustomError> {
+
+    if !requester.unwrap().is_privileged_user() {
+        return Err(CustomError::Forbidden);
+    }
+
+    let delted_podcast_episode = PodcastEpisodeService::delete_podcast_episode_locally(&id
+        .into_inner(), &mut db.get().unwrap())?;
+    lobby.do_send(BroadcastMessage{
+        podcast_episode: Some(delted_podcast_episode),
+        podcast_episodes: None,
+        type_of: PodcastType::DeletePodcastEpisode,
+        podcast: None,
+        message: "Deleted podcast episode locally".to_string()
+    });
+
+
+    return Ok(HttpResponse::NoContent().finish());
+}
+

--- a/src/controllers/podcast_episode_controller.rs
+++ b/src/controllers/podcast_episode_controller.rs
@@ -174,6 +174,6 @@ pub async fn delete_podcast_episode_locally(id: web::Path<String>,
     });
 
 
-    return Ok(HttpResponse::NoContent().finish());
+    Ok(HttpResponse::NoContent().finish())
 }
 

--- a/src/controllers/podcast_episode_controller.rs
+++ b/src/controllers/podcast_episode_controller.rs
@@ -130,11 +130,13 @@ pub async fn download_podcast_episodes_of_podcast(id: web::Path<String>, conn: D
             let podcast = Podcast::get_podcast(&mut conn.get().unwrap(), podcast_episode
                 .podcast_id).unwrap();
             PodcastEpisodeService::perform_download(
-                &podcast_episode,
-                podcast_episode.clone(),
+                &podcast_episode.clone(),
                 podcast,
                 &mut conn.get().unwrap(),
             ).unwrap();
+            PodcastEpisode::update_deleted(&mut conn.get().unwrap(),&podcast_episode.clone().episode_id,
+                                           false).unwrap();
+
         }
     });
 
@@ -147,7 +149,8 @@ pub async fn download_podcast_episodes_of_podcast(id: web::Path<String>, conn: D
 #[utoipa::path(
 context_path = "/api/v1",
 responses(
-(status = 204, description = "Starts the download of a given podcast episode")),
+(status = 204, description = "Removes the download of a given podcast episode. This very episode \
+won't be included in further checks/downloads unless done by user.")),
 tag = "podcast_episodes"
 )]
 #[delete("/episodes/{id}/download")]

--- a/src/dbconfig/schemas/postgresql/schema.rs
+++ b/src/dbconfig/schemas/postgresql/schema.rs
@@ -16,9 +16,9 @@ diesel::table! {
         username -> Varchar,
         device -> Varchar,
         podcast -> Varchar,
-        episode -> Varchar,
+        episode -> Text,
         timestamp -> Timestamp,
-        guid -> Nullable<Varchar>,
+        guid -> Nullable<Text>,
         action -> Varchar,
         started -> Nullable<Int4>,
         position -> Nullable<Int4>,
@@ -80,7 +80,8 @@ diesel::table! {
         description -> Text,
         status -> Bpchar,
         download_time -> Nullable<Timestamp>,
-        guid -> Varchar
+        guid -> Text,
+        deleted -> Bool,
     }
 }
 
@@ -109,8 +110,8 @@ diesel::table! {
         last_build_date -> Nullable<Text>,
         author -> Nullable<Text>,
         active -> Bool,
-        original_image_url -> Varchar,
-        directory_name -> Varchar,
+        original_image_url -> Text,
+        directory_name -> Text,
     }
 }
 

--- a/src/dbconfig/schemas/sqlite/schema.rs
+++ b/src/dbconfig/schemas/sqlite/schema.rs
@@ -66,6 +66,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    playlist_items (playlist_id, episode) {
+        playlist_id -> Text,
+        episode -> Integer,
+        position -> Integer,
+    }
+}
+
+diesel::table! {
+    playlists (id) {
+        id -> Text,
+        name -> Text,
+        user_id -> Integer,
+    }
+}
+
+diesel::table! {
     podcast_episodes (id) {
         id -> Integer,
         podcast_id -> Integer,
@@ -81,6 +97,7 @@ diesel::table! {
         status -> Text,
         download_time -> Nullable<Timestamp>,
         guid -> Text,
+        deleted -> Bool,
     }
 }
 
@@ -161,6 +178,8 @@ diesel::table! {
 }
 
 diesel::joinable!(favorites -> podcasts (podcast_id));
+diesel::joinable!(playlist_items -> playlists (playlist_id));
+diesel::joinable!(playlist_items -> podcast_episodes (episode));
 diesel::joinable!(podcast_episodes -> podcasts (podcast_id));
 diesel::joinable!(podcast_history_items -> podcasts (podcast_id));
 
@@ -171,6 +190,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     filters,
     invites,
     notifications,
+    playlist_items,
+    playlists,
     podcast_episodes,
     podcast_history_items,
     podcasts,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use crate::controllers::podcast_controller::{
     add_podcast_from_podindex, download_podcast, favorite_podcast, get_favored_podcasts,
     import_podcasts_from_opml, query_for_podcast, update_active_podcast,
 };
-use crate::controllers::podcast_episode_controller::{download_podcast_episodes_of_podcast, find_all_podcast_episodes_of_podcast, get_timeline};
+use crate::controllers::podcast_episode_controller::{delete_podcast_episode_locally, download_podcast_episodes_of_podcast, find_all_podcast_episodes_of_podcast, get_timeline};
 use crate::controllers::settings_controller::{get_opml, get_settings, run_cleanup, update_name, update_settings};
 use crate::controllers::sys_info_controller::{get_info, get_public_config, get_sys_info, login};
 use crate::controllers::watch_time_controller::{get_last_watched, get_watchtime, log_watchtime};
@@ -313,6 +313,7 @@ fn get_private_api() -> Scope<impl ServiceFactory<ServiceRequest, Config = (), R
         .service(add_podcast_from_podindex)
         .service(delete_podcast)
         .service(get_opml)
+        .service(delete_podcast_episode_locally)
 }
 
 pub fn config_secure_user_management(cfg: &mut web::ServiceConfig){

--- a/src/service/file_service.rs
+++ b/src/service/file_service.rs
@@ -104,12 +104,17 @@ impl FileService {
         PodcastEpisode::update_podcast_image(podcast_id, &file_path, conn).unwrap();
     }
 
-    pub fn cleanup_old_episode(podcast: Podcast, episode: PodcastEpisode) -> std::io::Result<()> {
+    pub fn cleanup_old_episode(podcast: Podcast, episode: PodcastEpisode) -> Result<(), CustomError> {
         log::info!("Cleaning up old episode: {}", episode.episode_id);
+        let settings = Setting::get_settings(&mut establish_connection())?;
+        println!("{}",format!(
+            "{}/'{}'",
+            podcast.directory_name, perform_replacement(&episode.name, settings.clone().unwrap())
+        ));
         std::fs::remove_dir_all(format!(
-            "podcasts/{}/{}",
-            podcast.directory_id, episode.episode_id
-        ))
+            "{}/'{}'",
+            podcast.directory_name, perform_replacement(&episode.name, settings.unwrap())
+        )).map_err(map_io_error)
     }
 
     pub fn delete_podcast_files(podcast_dir: &str){

--- a/src/service/file_service.rs
+++ b/src/service/file_service.rs
@@ -107,10 +107,6 @@ impl FileService {
     pub fn cleanup_old_episode(podcast: Podcast, episode: PodcastEpisode) -> Result<(), CustomError> {
         log::info!("Cleaning up old episode: {}", episode.episode_id);
         let settings = Setting::get_settings(&mut establish_connection())?;
-        println!("{}",format!(
-            "{}/'{}'",
-            podcast.directory_name, perform_replacement(&episode.name, settings.clone().unwrap())
-        ));
         std::fs::remove_dir_all(format!(
             "{}/'{}'",
             podcast.directory_name, perform_replacement(&episode.name, settings.unwrap())

--- a/src/service/mapping_service.rs
+++ b/src/service/mapping_service.rs
@@ -95,6 +95,7 @@ impl MappingService {
             status: podcast_episode.status.clone(),
             download_time: podcast_episode.download_time,
             guid: podcast_episode.guid.clone(),
+            deleted: podcast_episode.deleted,
         }
     }
 

--- a/src/service/podcast_episode_service.rs
+++ b/src/service/podcast_episode_service.rs
@@ -26,7 +26,7 @@ use crate::mutex::LockResultExt;
 use crate::service::environment_service::EnvironmentService;
 use crate::service::settings_service::SettingsService;
 use crate::service::telegram_api::send_new_episode_notification;
-use crate::utils::error::{CustomError, map_io_error};
+use crate::utils::error::{CustomError};
 
 #[derive(Clone)]
 pub struct PodcastEpisodeService {
@@ -494,7 +494,7 @@ impl PodcastEpisodeService {
         FileService::cleanup_old_episode(podcast, episode.clone().unwrap())?;
         PodcastEpisode::update_download_status_of_episode(episode.clone().unwrap().id, conn);
         PodcastEpisode::update_deleted(conn,episode_id, true)?;
-        return Ok(episode.unwrap())
+        Ok(episode.unwrap())
     }
 }
 

--- a/src/service/rust_service.rs
+++ b/src/service/rust_service.rs
@@ -206,16 +206,17 @@ impl PodcastService {
         match settings {
             Some(settings) => {
                 if settings.auto_download {
-                    let result = PodcastEpisodeService::
-                    get_last_n_podcast_episodes(conn, podcast.clone())?;
+                    let result = PodcastEpisodeService::get_last_n_podcast_episodes(conn, podcast.clone())?;
                     for podcast_episode in result {
-                        self.podcast_episode_service
-                            .download_podcast_episode_if_not_locally_available(
-                                podcast_episode,
-                                podcast.clone(),
-                                lobby.clone(),
-                                conn
-                            )?;
+                        if !podcast_episode.deleted {
+                            self.podcast_episode_service
+                                .download_podcast_episode_if_not_locally_available(
+                                    podcast_episode,
+                                    podcast.clone(),
+                                    lobby.clone(),
+                                    conn
+                                )?;
+                        }
                     }
                 }
                 Ok(())

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,7 +21,7 @@ import {
     checkIfOpmlAdded,
     checkIfOpmlErrored,
     checkIfPodcastAdded,
-    checkIfPodcastEpisodeAdded,
+    checkIfPodcastEpisodeAdded, checkIfPodcastEpisodeDeleted,
     checkIfPodcastRefreshed
 } from "./utils/MessageIdentifier"
 import {Notification} from "./models/Notification"
@@ -102,6 +102,18 @@ const App: FC<PropsWithChildren> = ({children}) => {
                         })
                         dispatch(setSelectedEpisodes(podcastUpdated))
                     }
+                }
+                else if (checkIfPodcastEpisodeDeleted(parsed)){
+                    const updatedPodcastEpisodes = store.getState().common.selectedEpisodes.map(e=>{
+                        if(e.episode_id === parsed.podcast_episode.episode_id){
+                            const clonedPodcast = Object.assign({}, parsed.podcast_episode);
+                            clonedPodcast.status = "N"
+                            return clonedPodcast
+                        }
+                        return e
+                    })
+                    enqueueSnackbar(t('podcast-episode-deleted', {name: parsed.podcast_episode.name}), {variant: "success"})
+                    dispatch(setSelectedEpisodes(updatedPodcastEpisodes))
                 }
                 else if (checkIfPodcastRefreshed(parsed)){
                     const podcast = parsed.podcast

--- a/ui/src/components/PodcastDetailItem.tsx
+++ b/ui/src/components/PodcastDetailItem.tsx
@@ -61,6 +61,11 @@ export const PodcastDetailItem:FC<PodcastDetailItemProps> = ({episode, index,epi
                         // Prevent icon click from triggering info modal
                         e.stopPropagation()
 
+                        // Prevent another download if already downloaded
+                        if (episode.status === 'D') {
+                            return
+                        }
+
                         axios.put(apiURL + "/podcast/" + episode.episode_id + "/episodes/download")
                             .then(()=>{
                                 enqueueSnackbar(t('episode-downloaded-to-server'), {variant: "success"})

--- a/ui/src/components/PodcastInfoModal.tsx
+++ b/ui/src/components/PodcastInfoModal.tsx
@@ -1,10 +1,11 @@
 import {createPortal} from "react-dom"
 import {useTranslation} from "react-i18next"
-import {preparePath, removeHTML} from "../utils/Utilities"
+import {apiURL, preparePath, removeHTML} from "../utils/Utilities"
 import {useAppDispatch, useAppSelector} from "../store/hooks"
 import {setInfoModalPodcastOpen} from "../store/CommonSlice"
 import {Heading2} from "./Heading2"
 import "material-symbols/outlined.css"
+import axios from "axios";
 
 export const PodcastInfoModal = () => {
     const dispatch = useAppDispatch()
@@ -21,6 +22,12 @@ export const PodcastInfoModal = () => {
         document.body.appendChild(element)
         element.click()
         document.body.removeChild(element)
+    }
+
+    const deleteEpisodeDownloadOnServer = (episodeId: string) => {
+        axios.delete(apiURL + "/episodes/" + episodeId + "/download").then(() => {
+            dispatch(setInfoModalPodcastOpen(false))
+        })
     }
 
     return createPortal( <div id="defaultModal" tabIndex={-1} aria-hidden="true" onClick={()=>dispatch(setInfoModalPodcastOpen(false))}
@@ -45,6 +52,7 @@ export const PodcastInfoModal = () => {
 
                         }
                     }}>save</span>
+                    {selectedPodcastEpisode?.status === 'D'&& <span onClick={()=>deleteEpisodeDownloadOnServer(selectedPodcastEpisode?.episode_id)} className="material-symbols-outlined align-middle cursor-pointer  text-red-600" title={t('delete') as string}>delete</span>}
                 </div>
 
                 {selectedPodcastEpisode&&<p className="leading-[1.75] text-sm text-stone-900" dangerouslySetInnerHTML={removeHTML(selectedPodcastEpisode.description)}>

--- a/ui/src/language/json/de.json
+++ b/ui/src/language/json/de.json
@@ -149,5 +149,6 @@
   "standard-episode-format-explanation":"Gibt das Standardformat für die Episoden an. Dies wirkt sich lediglich auf die Ordnerstruktur und deren Benamung aus.",
   "standard-podcast-format-explanation":"Gibt das Standardformat für die Podcasts an. Dies wirkt sich lediglich auf die Ordnerstruktur und deren Benamung aus.",
   "colon-replacement-explanation": "Gibt an, durch welches Zeichen der Doppelpunkt ersetzt werden soll. Dies ist nützlich, da der Doppelpunkt nicht im Dateinamen verwendet werden kann.",
-  "already-added": "Podcast {{name}} bereits hinzugefügt"
+  "already-added": "Podcast {{name}} bereits hinzugefügt",
+  "podcast-episode-deleted": "Podcast-Episode {{name}} gelöscht"
 }

--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -150,5 +150,6 @@
   "standard-podcast-format-explanation": "Specifies the standard format for the podcasts. This only affects the folder structure and naming.",
   "standard-episode-format-explanation": "Specifies the standard format for the episodes. This only affects the folder structure and naming.",
   "colon-replacement-explanation": "Specifies by which character the colon should be replaced. This is useful because the colon cannot be used in the file name.",
-  "already-added": "Podcast {{name}} already added"
+  "already-added": "Podcast {{name}} already added",
+  "podcast-episode-deleted": "Podcast episode {{name}} deleted"
 }

--- a/ui/src/language/json/es.json
+++ b/ui/src/language/json/es.json
@@ -148,5 +148,6 @@
   "auto-download-explanation": "Si esta opción está activa, los episodios se descargarán automáticamente cuando se añada un podcast",
   "default-episode-format-explanation": "Especifica el formato por defecto para los episodios. Solo afecta la estructura de directorio y su nomenclatura.",
   "standard-podcast-format-explanation": "Especifica el formato estándar para los podcasts. Solo afecta la estructura de directorio y su nomenclatura",
-  "colon-replacement-explanation": "Especifica el carácter que sustituirá a los dos puntos. Esto es útil ya que los dos puntos no se pueden usar en un nombre de fichero."
+  "colon-replacement-explanation": "Especifica el carácter que sustituirá a los dos puntos. Esto es útil ya que los dos puntos no se pueden usar en un nombre de fichero.",
+  "podcast-episode-deleted": "Episodio {{name}} borrado"
 }

--- a/ui/src/language/json/fr.json
+++ b/ui/src/language/json/fr.json
@@ -149,5 +149,6 @@
   "standard-episode-format-explanation" : "Spécifie le format par défaut pour les épisodes. Cela n'a d'effet que sur la structure des dossiers et leur dénomination",
   "standard-podcast-format-explanation" : "Indique le format par défaut pour les podcasts. Cela n'affecte que la structure des dossiers et leur dénomination.",
   "colon-replacement-explanation" : "Indique par quel caractère le deux-points doit être remplacé. Ceci est utile car le deux-points ne peut pas être utilisé dans le nom de fichier",
-  "already-added": "Podcast {{name}} déjà ajouté"
+  "already-added": "Podcast {{name}} déjà ajouté",
+  "podcast-episode-deleted": "Épisode {{name}} supprimé"
 }

--- a/ui/src/language/json/pl.json
+++ b/ui/src/language/json/pl.json
@@ -149,5 +149,6 @@
   "default-episode-format-explanation": "Format nazw plików odcinków. To ustawienie dotyczy jedynie struktury plików i katalogów oraz ich nazewnictwa.",
   "standard-podcast-format-explanation": "Format nazw podcastów. To ustawienie dotyczy jedynie struktury plików i katalogów oraz ich nazewnictwa.",
   "colon-replacement-explanation": "Określa sposób zamiany dwukropka na inny znak. PodFetch nie zezwala na występowanie dwukropków w nazwach plików.",
-  "already-added": "Podcast {{name}} został już dodany."
+  "already-added": "Podcast {{name}} został już dodany.",
+  "podcast-episode-deleted": "Odcinek {{name}} został usunięty."
 }

--- a/ui/src/models/messages/BroadcastMesage.ts
+++ b/ui/src/models/messages/BroadcastMesage.ts
@@ -18,6 +18,10 @@ export interface PodcastEpisodeAdded extends BroadcastMesage, PodcastAdded {
     podcast_episode: PodcastEpisode
 }
 
+export interface PodcastEpisodeDeleted extends BroadcastMesage, PodcastAdded {
+    podcast_episode: PodcastEpisode
+}
+
 export interface PodcastEpisodeAdded extends BroadcastMesage {
     podcast_episode: PodcastEpisode
 }

--- a/ui/src/utils/MessageIdentifier.ts
+++ b/ui/src/utils/MessageIdentifier.ts
@@ -1,7 +1,7 @@
 import {
     BroadcastMesage,
     PodcastAdded,
-    PodcastEpisodeAdded, PodcastRefreshed
+    PodcastEpisodeAdded, PodcastEpisodeDeleted, PodcastRefreshed
 } from "../models/messages/BroadcastMesage";
 
 export const checkIfPodcastAdded = (message: BroadcastMesage): message is PodcastAdded => {
@@ -10,6 +10,10 @@ export const checkIfPodcastAdded = (message: BroadcastMesage): message is Podcas
 
 export const checkIfPodcastEpisodeAdded = (message: BroadcastMesage): message is PodcastEpisodeAdded => {
     return message.type_of === MessageType.ADD_PODCAST_EPISODE
+}
+
+export const checkIfPodcastEpisodeDeleted = (message: BroadcastMesage): message is PodcastEpisodeDeleted => {
+    return message.type_of === MessageType.DeletePodcastEpisode
 }
 
 export const checkIfPodcastEpisodesAdded = (message: BroadcastMesage): message is PodcastAdded => {
@@ -34,5 +38,6 @@ enum MessageType {
     ADD_PODCAST_EPISODES = "AddPodcastEpisodes",
     REFRESH_PODCAST = "RefreshPodcast",
     OpmlAdded  = "OpmlAdded",
-    OpmlErrored = "OpmlErrored"
+    OpmlErrored = "OpmlErrored",
+    DeletePodcastEpisode = "DeletePodcastEpisode"
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds the option to delete an already downloaded podcast episode. The podcast won't be downloaded again until this is performed manually by the user

### Linked Issues
Closes #221
