### PR TITLE
Fix podcast total duration in HiddenAudioPlayer on Firefox

### DIFF
--- a/ui/src/components/HiddenAudioPlayer.tsx
+++ b/ui/src/components/HiddenAudioPlayer.tsx
@@ -26,7 +26,7 @@ export const HiddenAudioPlayer: FC<HiddenAudioPlayerProps> = ({ refItem, setAudi
                     .then((response: AxiosResponse<PodcastWatchedModel>) => {
                         setCurrentPodcastEpisode({
                             ...podcastEpisode,
-                            time: response.data.watchedTime
+                            time: response.data.position
                         })
                         refItem.current!.currentTime = podcastEpisode.time!
                     })
@@ -61,6 +61,21 @@ export const HiddenAudioPlayer: FC<HiddenAudioPlayerProps> = ({ refItem, setAudi
                     duration: e.currentTarget.duration,
                     percentage: 0
                 })
+                
+                if (isNaN(e.currentTarget.duration)) {
+                    // Need alternative method of getting duration
+                    // Firefox doesn't load the entire file before playing
+                    // causing a changing duration, but the onLoadedMetadata event
+                    // is only called once rendering the progressbar useless
+                     axios.get('/podcast/episode/' + podcastEpisode.episode_id)
+                       .then((response: AxiosResponse<PodcastWatchedModel>) => {
+                           setMetadata({
+                               currentTime: e.currentTarget.currentTime,
+                               duration: response.data.total,
+                               percentage: 0
+                           })
+                       })
+                }
             }}
         />
     )


### PR DESCRIPTION
### Description

Firefox doesn't load the entire file before playing resulting in the duration of the audio element changing until playback is near the end of the file, but the onLoadedMetadata event doesn't get triggered again. This results in the progress bar just displaying infinity and NaN on Firefox.

This pr adds a fallback, if the total duration is NaN a request is sent to `/podcast/episode/{id}` to retrieve the total duration and updates the audio metadata with the correct duration.

### Linked Issues
None
