### PR TITLE
Fix panic error when downloading podcast with existing ID3v2.2 tags.

### DIFF
--- a/src/service/download_service.rs
+++ b/src/service/download_service.rs
@@ -151,6 +151,10 @@ impl DownloadService {
             Err(err) => return Err(CustomError::Conflict(err.to_string())),
         };
 
+        if let Version::Id3v22 = tag.version() {
+            tag = Tag::new();
+        }
+
         if let 0 = tag.pictures().count() {
             let mut image_file = std::fs::File::open(paths.image_filename).unwrap();
             let mut image_data = Vec::new();


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This pull request fixes #658 by checking if a podcast episode's tags are ID3v2.2 when downloading. If they are, a completely new tag is generated in the default format (ID3v2.4).

### Linked Issues

#658 and #690 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
The panic error was caused by the podcast episodes having ID3v2.2 tags which use three character frames. Since the existing tags are used as a baseline and the tag being written to new downloads is ID3v2.4 which use four character frames, there was a panic error due to the mismatch.

Thank you for your work on this project and the guidance via commit #690 so I could find the right area to explore!