### PR TITLE
Add playback control hotkeys

### DIFF
--- a/ui/src/components/EpisodeSearchModal.tsx
+++ b/ui/src/components/EpisodeSearchModal.tsx
@@ -10,12 +10,16 @@ export const EpisodeSearchModal = () => {
 
     useCtrlPressed(() => {
         setOpen(!open)
-
-        document.getElementById('search-input')!.focus()
+        if (open) {
+            document.getElementById('search-input')!.blur()
+        } else {
+            document.getElementById('search-input')!.focus()
+        }
     }, ['f'])
 
     useKeyDown(() => {
         setOpen(false)
+        document.getElementById('search-input')!.blur()
     }, ['Escape'])
 
     return createPortal(

--- a/ui/src/components/PlayerProgressBar.tsx
+++ b/ui/src/components/PlayerProgressBar.tsx
@@ -55,7 +55,7 @@ export const PlayerProgressBar: FC<PlayerProgressBarProps> = ({ audioplayerRef, 
     }, [minute])
 
     if (audioplayerRef === undefined || audioplayerRef.current === undefined || metadata === undefined) {
-        return <div>test</div>
+        return <div></div>
     }
 
     const endWrapperPosition = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/ui/src/components/PlayerTimeControls.tsx
+++ b/ui/src/components/PlayerTimeControls.tsx
@@ -8,6 +8,7 @@ import useAudioPlayer from '../store/AudioPlayerSlice'
 import 'material-symbols/outlined.css'
 import axios, {AxiosResponse} from "axios";
 import {PodcastWatchedModel} from "../models/PodcastWatchedModel";
+import { useKeyDown } from '../hooks/useKeyDown'
 import useCommon from "../store/CommonSlice";
 import {EpisodesWithOptionalTimeline} from "../models/EpisodesWithOptionalTimeline";
 import {Episode} from "../models/Episode";
@@ -127,16 +128,34 @@ export const PlayerTimeControls: FC<PlayerTimeControlsProps> = ({ refItem }) => 
         setPlaybackRate(SPEED_STEPS[currentIndex + 1])
     }
 
+    const seekForward = () => {
+        if (refItem === undefined || refItem.current === undefined || refItem.current === null) return
+
+        if (refItem.current.currentTime + SKIPPED_TIME < refItem.current.duration) {
+            refItem.current.currentTime += SKIPPED_TIME
+        }
+    }
+
+    const seekBackward = () => {
+        if (refItem === undefined || refItem.current === undefined || refItem.current === null) return
+
+        if (refItem.current.currentTime - SKIPPED_TIME > 0 ) {
+            refItem.current.currentTime -= SKIPPED_TIME
+        } else {
+            refItem.current.currentTime = 0
+        }
+    }
+
+    useKeyDown(seekBackward, ['j', 'ArrowLeft'], false)
+
+    useKeyDown(seekForward, ['l', 'ArrowRight'], false)
+
+    useKeyDown(handleButton, ['k', ' '], false)
+
     return (
         <div className="flex items-center justify-center gap-6">
             {/* Skip back */}
-            <span className="material-symbols-outlined cursor-pointer text-2xl lg:text-3xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90 " onClick={() => {
-                if (refItem.current === undefined || refItem.current === null) return
-
-                if (refItem.current.currentTime - SKIPPED_TIME > 0 ) {
-                    refItem.current.currentTime -= SKIPPED_TIME
-                }
-            }}>replay_30</span>
+            <span className="material-symbols-outlined cursor-pointer text-2xl lg:text-3xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90 " onClick={() => seekBackward()}>replay_30</span>
 
             {/* Previous */}
             <span className="material-symbols-outlined filled cursor-pointer text-3xl lg:text-4xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90" onClick={() => skipToPreviousEpisode()}>skip_previous</span>
@@ -153,13 +172,7 @@ export const PlayerTimeControls: FC<PlayerTimeControlsProps> = ({ refItem }) => 
             <span className="material-symbols-outlined filled cursor-pointer text-3xl lg:text-4xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90" onClick={() => skipToNextEpisode()}>skip_next</span>
 
             {/* Skip forward */}
-            <span className="material-symbols-outlined cursor-pointer text-2xl lg:text-3xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90 " onClick={() => {
-                if (refItem.current === undefined || refItem.current === null) return
-
-                if (refItem.current.currentTime + SKIPPED_TIME < refItem.current.duration) {
-                    refItem.current.currentTime += SKIPPED_TIME
-                }
-            }}>forward_30</span>
+            <span className="material-symbols-outlined cursor-pointer text-2xl lg:text-3xl text-[--fg-color] hover:text-[--fg-color-hover] active:scale-90 " onClick={() => seekForward()}>forward_30</span>
 
             {/* Speed fixed width to prevent layout shift when value changes */}
             <span className="cursor-pointer text-sm text-[--fg-color] hover:text-[--fg-color-hover] w-8" onClick={() => changeSpeed()}>{speed}x</span>

--- a/ui/src/components/PlayerVolumeSlider.tsx
+++ b/ui/src/components/PlayerVolumeSlider.tsx
@@ -3,6 +3,8 @@ import * as Slider from '@radix-ui/react-slider'
 import useAudioPlayer from '../store/AudioPlayerSlice'
 import { AudioAmplifier } from '../models/AudioAmplifier'
 import { VolumeIcon } from '../icons/VolumeIcon'
+import { useKeyDown } from '../hooks/useKeyDown'
+import { VOLUME_STEP } from '../utils/Utilities';
 
 type PlayerVolumeSliderProps = {
     refItem: RefObject<HTMLAudioElement|null>,
@@ -12,6 +14,22 @@ type PlayerVolumeSliderProps = {
 export const PlayerVolumeSlider: FC<PlayerVolumeSliderProps> = ({ refItem, audioAmplifier }) => {
     const volume = useAudioPlayer(state => state.volume)
     const setVolume = useAudioPlayer(state => state.setVolume)
+
+    useKeyDown(() => {
+        if (refItem.current) {
+            const newVolume = Math.max(0, volume - VOLUME_STEP)
+            setVolume(newVolume)
+            audioAmplifier && audioAmplifier.setVolume(newVolume / 100)
+        }
+    }, ['ArrowDown'], false)
+
+    useKeyDown(() => {
+        if (refItem.current) {
+            const newVolume = Math.min(300, volume + VOLUME_STEP)
+            setVolume(newVolume)
+            audioAmplifier && audioAmplifier.setVolume(newVolume / 100)
+        }
+    }, ['ArrowUp'], false)
 
     return (
         <div className="flex items-center gap-2 w-40 sm:w-full sm:px-0">

--- a/ui/src/hooks/useKeyDown.ts
+++ b/ui/src/hooks/useKeyDown.ts
@@ -1,7 +1,10 @@
 import {useEffect} from "react";
 
-export const useKeyDown = (callback:any, keys:string[]) => {
+export const useKeyDown = (callback:any, keys:string[], triggerOnInputField:boolean=true) => {
     const onKeyDown = (event: KeyboardEvent) => {
+        if (!triggerOnInputField && (event.target as HTMLElement).tagName === 'INPUT') {
+            return;
+        }
         const wasAnyKeyPressed = keys.some((key: string) => event.key === key);
         if (wasAnyKeyPressed) {
             event.preventDefault();

--- a/ui/src/utils/Utilities.tsx
+++ b/ui/src/utils/Utilities.tsx
@@ -32,6 +32,7 @@ TimeAgo.addLocale(es)
 TimeAgo.addLocale(fr)
 
 export const SKIPPED_TIME = 30
+export const VOLUME_STEP = 5
 let timeago = new TimeAgo('en-US')
 
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds hotkeys to control the media playback. I recently started using PodFetch and noticed that it doesn't seek/pause/play the player when using the arrow keys when using a keyboard. I use them when on desktop and I think it would be a nice addition
J / Left Arrow - Skip backwards
K / Space - Toggle pause/play
L / Right Arrow - Skip forward
Up / Down Arrow - Volume control

### Linked Issues

No issues open from what I found

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Other than the obvious keybinds, I added `triggerOnInputField` to the `useKeyDown` function. This default to `true` right now to avoid conflicts with other potential usages in the application
Added some `blur()` calls to the search input field as it was kept active even when not displayed on screen (also conflicted with the control hotkeys)
