### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -52,6 +55,8 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+          contents: write
         with:
           files: |
             podfetch-linux.zip
@@ -120,6 +125,8 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+          contents: write
         with:
           files: |
             podfetch-win.zip
@@ -178,6 +185,8 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+          contents: write
         with:
           files: |
             podfetch-apple.zip


### PR DESCRIPTION
Potential fix for [https://github.com/SamTV12345/PodFetch/security/code-scanning/12](https://github.com/SamTV12345/PodFetch/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for each job. Specifically:
1. At the workflow level, we will set `contents: read` as the default permission for all jobs.
2. For jobs that require additional permissions (e.g., `contents: write` for release steps), we will override the default permissions by specifying job-specific `permissions` blocks.

This approach ensures that each job has only the permissions it needs, reducing the risk of unauthorized actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
