### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'main'
 name: Test rust
+permissions:
+  contents: read
 
 jobs:
   build_all_features:


### PR DESCRIPTION
Potential fix for [https://github.com/SamTV12345/PodFetch/security/code-scanning/11](https://github.com/SamTV12345/PodFetch/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only performs read operations (e.g., checking out code, caching dependencies, and running tests), we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
