### PR TITLE
Ensure PodcastEpisodeService::get_url_file_suffix strips URL parameters before determining the extension

### DIFF
--- a/.github/workflows/checkFrontend.yml
+++ b/.github/workflows/checkFrontend.yml
@@ -2,7 +2,10 @@ name: checkFrontend.yml
 permissions:
   contents: read
 on:
+  pull_request: {}
   push:
+    branches:
+      - 'main'
 
 jobs:
   check-frontend:

--- a/src/service/podcast_episode_service.rs
+++ b/src/service/podcast_episode_service.rs
@@ -31,6 +31,7 @@ use std::ffi::OsStr;
 use std::io::Error;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use url::Url;
 
 pub struct PodcastEpisodeService;
 
@@ -372,7 +373,7 @@ impl PodcastEpisodeService {
         }?;
         let file_name = converted_url.path_segments().iter().last().ok_or(Error::other("No"))?;
         file_name.rsplit('.').next().filter(|s| *s != file_name).map(|s| s.to_string())*/
-        Ok(Path::new(url)
+        Ok(Path::new(Url::parse(url).unwrap().set_query(None))
             .extension()
             .unwrap_or(OsStr::new(""))
             .to_string_lossy()

--- a/src/service/podcast_episode_service.rs
+++ b/src/service/podcast_episode_service.rs
@@ -373,7 +373,9 @@ impl PodcastEpisodeService {
         }?;
         let file_name = converted_url.path_segments().iter().last().ok_or(Error::other("No"))?;
         file_name.rsplit('.').next().filter(|s| *s != file_name).map(|s| s.to_string())*/
-        Ok(Path::new(Url::parse(url).unwrap().set_query(None))
+        let mut url = Url::parse(url).unwrap();
+        url.set_query(None);
+        Ok(Path::new(&String::from(url))
             .extension()
             .unwrap_or(OsStr::new(""))
             .to_string_lossy()

--- a/src/utils/file_extension_determination.rs
+++ b/src/utils/file_extension_determination.rs
@@ -65,6 +65,7 @@ fn get_suffix_by_url(url: &str) -> Result<String, Error> {
 
 #[cfg(test)]
 mod tests {
+    use crate::service::podcast_episode_service::PodcastEpisodeService;
     use serial_test::serial;
 
     // From https://github.com/parshap/node-sanitize-filename/blob/master/test.js
@@ -79,10 +80,10 @@ mod tests {
 
     static URL_EXTENSIONS: &[&str] = &[
         "",
-        ".jpg",
-        ".mp3",
-        ".mp3",
-        ".jpg",
+        "jpg",
+        "mp3",
+        "mp3",
+        "jpg",
         "",
     ];
 
@@ -91,7 +92,7 @@ mod tests {
     fn it_works() {
         // Check extensions are correctly determined
         for (idx, url) in URLS.iter().enumerate() {
-            assert_eq!(get_suffix_by_url(url), URL_EXTENSIONS[idx]);
+            assert_eq!(PodcastEpisodeService::get_url_file_suffix(url).unwrap(), URL_EXTENSIONS[idx]);
         }
     }
 }

--- a/src/utils/file_extension_determination.rs
+++ b/src/utils/file_extension_determination.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn it_works() {
+    fn stripping_filename_works() {
         // Check extensions are correctly determined
         for (idx, url) in URLS.iter().enumerate() {
             assert_eq!(PodcastEpisodeService::get_url_file_suffix(url).unwrap(), URL_EXTENSIONS[idx]);

--- a/src/utils/file_extension_determination.rs
+++ b/src/utils/file_extension_determination.rs
@@ -62,3 +62,36 @@ pub fn determine_file_extension(
 fn get_suffix_by_url(url: &str) -> Result<String, Error> {
     PodcastEpisodeService::get_url_file_suffix(url)
 }
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    // From https://github.com/parshap/node-sanitize-filename/blob/master/test.js
+    static URLS: &[&str] = &[
+        "http://www.contoso.com/test",
+        "http://www.contoso.com/test.jpg",
+        "http://www.contoso.com/test.mp3",
+        "http://www.contoso.com/test.mp3?Parameter1=42",
+        "http://www.contoso.com/test.jpg?Parameter1=test&Parameter2=42",
+        "http://www.contoso.com/test?Parameter1=test&Parameter2=42",
+    ];
+
+    static URL_EXTENSIONS: &[&str] = &[
+        "",
+        ".jpg",
+        ".mp3",
+        ".mp3",
+        ".jpg",
+        "",
+    ];
+
+    #[test]
+    #[serial]
+    fn it_works() {
+        // Check extensions are correctly determined
+        for (idx, url) in URLS.iter().enumerate() {
+            assert_eq!(get_suffix_by_url(url), URL_EXTENSIONS[idx]);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Filenames are being incorrectly written to disk if the URL contains parameters.  As an example, podcast.mp3?TimeRemaining=42

### Linked Issues

There's not been an issue raised for this yet, but the code in question has been changed fairly recently.

### Additional context

Tests added which fail with the old method, and pass with the new.  I'm not very familiar with Rust, so please do correct any rookie errors!
