### PR TITLE
fix: seed no-auth standard user so FK-bound writes succeed (#2109)

### DIFF
--- a/crates/podfetch-domain/src/user_admin.rs
+++ b/crates/podfetch-domain/src/user_admin.rs
@@ -94,6 +94,11 @@ pub trait UserAdminRepository: Send + Sync {
     type Error;
 
     fn create(&self, user: ManagedUser) -> Result<ManagedUser, Self::Error>;
+    /// Insert a user with an explicit primary key, doing nothing if a row with
+    /// that id already exists. Unlike [`create`], which lets the database assign
+    /// the id, this preserves the supplied id so fixed identities (e.g. the
+    /// no-auth standard user) can be seeded deterministically.
+    fn ensure_with_id(&self, user: ManagedUser) -> Result<ManagedUser, Self::Error>;
     fn find_by_api_key(&self, api_key: &str) -> Result<Option<ManagedUser>, Self::Error>;
     fn find_by_username(&self, username: &str) -> Result<Option<ManagedUser>, Self::Error>;
     fn find_all(&self) -> Result<Vec<ManagedUser>, Self::Error>;

--- a/crates/podfetch-persistence/src/adapters.rs
+++ b/crates/podfetch-persistence/src/adapters.rs
@@ -770,6 +770,10 @@ impl UserAdminRepository for UserAdminRepositoryImpl {
         self.inner.create(user).map_err(Into::into)
     }
 
+    fn ensure_with_id(&self, user: ManagedUser) -> Result<ManagedUser, Self::Error> {
+        self.inner.ensure_with_id(user).map_err(Into::into)
+    }
+
     fn find_by_api_key(&self, api_key: &str) -> Result<Option<ManagedUser>, Self::Error> {
         self.inner.find_by_api_key(api_key).map_err(Into::into)
     }

--- a/crates/podfetch-persistence/src/user_admin.rs
+++ b/crates/podfetch-persistence/src/user_admin.rs
@@ -108,6 +108,31 @@ impl UserAdminRepository for DieselUserAdminRepository {
             .map_err(Into::into)
     }
 
+    fn ensure_with_id(&self, user: ManagedUser) -> Result<ManagedUser, Self::Error> {
+        use self::users::dsl::*;
+
+        let mut conn = self.database.connection()?;
+        let entity = UserEntity::from(user);
+
+        // Check-then-insert keeps this idempotent without relying on
+        // backend-specific upsert (`on_conflict`), which is not supported
+        // uniformly across the `MultiConnection` backends. The seed runs once at
+        // startup on a single thread, so the gap between the two queries is safe.
+        if let Some(existing) = users
+            .filter(id.eq(entity.id))
+            .first::<UserEntity>(&mut conn)
+            .optional()?
+        {
+            return Ok(existing.into());
+        }
+
+        diesel::insert_into(users)
+            .values(&entity)
+            .get_result::<UserEntity>(&mut conn)
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+
     fn find_by_api_key(&self, api_key_to_find: &str) -> Result<Option<ManagedUser>, Self::Error> {
         use self::users::dsl::*;
 

--- a/crates/podfetch-web/src/services/user_auth/service.rs
+++ b/crates/podfetch-web/src/services/user_auth/service.rs
@@ -122,6 +122,37 @@ impl UserAuthService {
         })
     }
 
+    /// Persist the synthetic standard user so foreign keys that reference it
+    /// resolve to a real row.
+    ///
+    /// When no named admin `USERNAME` is configured, every request is attributed
+    /// to the in-memory [`Self::read_only_admin_user`] (id [`STANDARD_USER_ID`]).
+    /// That user is never written to the `users` table, so any write keyed on it
+    /// (`filters.user_id`, `podcasts.added_by`, …) fails the
+    /// `REFERENCES users(id)` constraint. Seeding the row once at startup keeps
+    /// the constraint intact while making the reference valid.
+    ///
+    /// No-op when a named admin username is configured, since the requester is
+    /// then a real database user rather than the standard user.
+    pub fn ensure_standard_user_present(&self) -> Result<(), CustomError> {
+        if self.environment.username.is_some() {
+            return Ok(());
+        }
+
+        self.repository.ensure_with_id(ManagedUser {
+            id: STANDARD_USER_ID,
+            username: STANDARD_USER.to_string(),
+            role: Role::Admin.to_string(),
+            password: None,
+            explicit_consent: true,
+            created_at: chrono::Utc::now().naive_utc(),
+            api_key: self.environment.api_key_admin.clone(),
+            country: None,
+            language: None,
+        })?;
+        Ok(())
+    }
+
     pub fn read_only_admin_user(&self) -> User {
         User {
             id: STANDARD_USER_ID,
@@ -134,5 +165,98 @@ impl UserAuthService {
             country: None,
             language: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::tests::handle_test_startup;
+    use common_infrastructure::config::EnvironmentService;
+    use podfetch_domain::filter::{Filter, FilterRepository};
+    use podfetch_persistence::adapters::{FilterRepositoryImpl, UserAdminRepositoryImpl};
+    use podfetch_persistence::db::database;
+    use serial_test::serial;
+
+    /// Build a `UserAuthService` that behaves like a deployment with **no**
+    /// configured admin username (the no-auth mode from the bug report), backed
+    /// by the real migrated test database.
+    fn no_auth_service() -> UserAuthService {
+        let mut environment = EnvironmentService::for_tests();
+        environment.username = None;
+        UserAuthService::new(
+            Arc::new(UserAdminRepositoryImpl::new(database())),
+            Arc::new(environment),
+        )
+    }
+
+    /// Regression test for "Unable to add new podcast feed" (#2109).
+    ///
+    /// In no-auth mode every request is attributed to the standard user
+    /// (id [`STANDARD_USER_ID`]), which historically was never written to the
+    /// `users` table. Any write keyed on that id then failed the
+    /// `REFERENCES users(id)` foreign key. Seeding the row keeps the FK intact
+    /// while making the reference valid.
+    #[tokio::test]
+    #[serial]
+    async fn standard_user_is_seeded_so_fk_bound_writes_succeed() {
+        // Migrates the DB, enables `PRAGMA foreign_keys = ON`, and starts clean.
+        let _ts = handle_test_startup().await;
+
+        let service = no_auth_service();
+        let filter_repo = FilterRepositoryImpl::new(database());
+        let standard_filter = || Filter::new(STANDARD_USER_ID, None, true, None, false);
+
+        // The requester in no-auth mode is the standard user...
+        assert_eq!(service.read_only_admin_user().id, STANDARD_USER_ID);
+        // ...but it does not yet exist in the database.
+        assert!(
+            service.repository.find_by_username(STANDARD_USER).unwrap().is_none(),
+            "standard user must be absent before seeding",
+        );
+
+        // Reproduces the bug: a write referencing the absent user violates the FK.
+        assert!(
+            filter_repo.save(standard_filter()).is_err(),
+            "FK must reject a reference to a non-existent user",
+        );
+
+        // The fix: seed the standard user once.
+        service.ensure_standard_user_present().unwrap();
+
+        let seeded = service
+            .repository
+            .find_by_username(STANDARD_USER)
+            .unwrap()
+            .expect("standard user must exist after seeding");
+        assert_eq!(seeded.id, STANDARD_USER_ID, "seed must preserve the fixed id");
+
+        // Idempotent: a second startup must not error or duplicate.
+        service.ensure_standard_user_present().unwrap();
+
+        // The previously-failing FK-bound write now succeeds.
+        filter_repo
+            .save(standard_filter())
+            .expect("filter save must succeed once the standard user exists");
+    }
+
+    /// When a named admin username is configured the requester is a real
+    /// database user, so the standard user must not be seeded.
+    #[tokio::test]
+    #[serial]
+    async fn standard_user_is_not_seeded_when_admin_username_configured() {
+        let _ts = handle_test_startup().await;
+
+        let service = UserAuthService::new(
+            Arc::new(UserAdminRepositoryImpl::new(database())),
+            Arc::new(EnvironmentService::for_tests()),
+        );
+
+        service.ensure_standard_user_present().unwrap();
+
+        assert!(
+            service.repository.find_by_username(STANDARD_USER).unwrap().is_none(),
+            "standard user must not be seeded when a named admin is configured",
+        );
     }
 }

--- a/crates/podfetch-web/src/startup.rs
+++ b/crates/podfetch-web/src/startup.rs
@@ -383,6 +383,11 @@ pub fn build_server_router() -> Router {
     insert_default_settings_if_not_present(state.settings_service.as_ref())
         .expect("Could not insert default settings");
 
+    state
+        .user_auth_service
+        .ensure_standard_user_present()
+        .expect("Could not seed standard user");
+
     if ENVIRONMENT_SERVICE.audiobookshelf_integration_enabled
         && let Err(e) = state.audiobookshelf_library_service.bootstrap_defaults()
     {


### PR DESCRIPTION
## Problem

Fixes #2109. On a fresh install with **no auth configured** (no `USERNAME` env var), podcast search and adding feeds returned `500`, and existing subscriptions appeared to vanish:

```
❌ - Database error: FOREIGN KEY constraint failed
❌ - GET /api/v1/podcasts/search?... -> 500
❌ - POST /api/v1/podcasts/itunes -> 500
```

### Root cause

In no-auth mode, `ensure_admin_user()` attributes every request to a synthetic `User { id: 9999 }` (`read_only_admin_user`) that is **never written to the `users` table**. The `username_to_user_id` migration (2026-04-15) added `REFERENCES users(id)` foreign keys on `filters.user_id` and `podcasts.added_by`. So any write keyed on that id failed the constraint:

- `GET /podcasts/search` → `save_filter(user_id = 9999)` → FK failure → 500 → the UI can't load podcasts (subscriptions "disappear", though the rows are still there).
- `POST /podcasts/itunes` → `added_by = 9999` → FK failure → can't add feeds.

This reproduced on both SQLite and Postgres (FKs always enforced on PG). The `database is locked` lines are a separate transient SQLite-startup symptom, not the blocker.

## Fix

Keep the foreign keys intact and make the reference real — **seed the standard user row once at startup** when no named admin is configured.

- `UserAdminRepository::ensure_with_id` — idempotent explicit-id insert (check-then-insert, backend-agnostic; avoids `on_conflict`, which `MultiConnection` doesn't support uniformly).
- `UserAuthService::ensure_standard_user_present()` — seeds id 9999 only when `username.is_none()`; no-op otherwise.
- Called from `build_server_router` (shared by prod and tests).

No data migration needed for affected users: the `podcasts` rows were preserved; they were just unreadable because `search` 500'd, and reappear once the seed exists.

## Tests

- Regression test reproduces the bug end-to-end: the orphan filter write **fails** the FK, seeding makes it succeed, the seed is idempotent, and it's skipped when an admin username is configured.
- `cargo check --workspace` (sqlite + postgres) clean; new tests and all user-related tests pass.
