### PR TITLE
feat: NFO files, {episodeNumber} token & Jellyfin polish (#315)

### DIFF
--- a/crates/podfetch-domain/src/podcast_settings.rs
+++ b/crates/podfetch-domain/src/podcast_settings.rs
@@ -17,6 +17,8 @@ pub struct PodcastSetting {
     pub activated: bool,
     pub podcast_prefill: i32,
     pub use_one_cover_for_all_episodes: bool,
+    pub nfo_format: String,
+    pub cover_filename: String,
 }
 
 pub trait PodcastSettingsRepository: Send + Sync {

--- a/crates/podfetch-domain/src/settings.rs
+++ b/crates/podfetch-domain/src/settings.rs
@@ -24,6 +24,10 @@ pub struct Setting {
     pub max_parallel_downloads: i32,
     /// Enable SponsorBlock for this instance.
     pub sponsorblock_enabled: bool,
+    /// Jellyfin/Kodi NFO format: "off" | "tvshow" | "album".
+    pub nfo_format: String,
+    /// Base name of the podcast cover file (default "image").
+    pub cover_filename: String,
 }
 
 #[derive(Clone)]

--- a/crates/podfetch-persistence/src/podcast_settings.rs
+++ b/crates/podfetch-persistence/src/podcast_settings.rs
@@ -22,6 +22,8 @@ diesel::table! {
         activated -> Bool,
         podcast_prefill -> Integer,
         use_one_cover_for_all_episodes -> Bool,
+        nfo_format -> Text,
+        cover_filename -> Text,
     }
 }
 
@@ -43,6 +45,8 @@ struct PodcastSettingEntity {
     activated: bool,
     podcast_prefill: i32,
     use_one_cover_for_all_episodes: bool,
+    nfo_format: String,
+    cover_filename: String,
 }
 
 impl From<PodcastSettingEntity> for PodcastSetting {
@@ -63,6 +67,8 @@ impl From<PodcastSettingEntity> for PodcastSetting {
             activated: value.activated,
             podcast_prefill: value.podcast_prefill,
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }
@@ -85,6 +91,8 @@ impl From<PodcastSetting> for PodcastSettingEntity {
             activated: value.activated,
             podcast_prefill: value.podcast_prefill,
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }

--- a/crates/podfetch-persistence/src/settings.rs
+++ b/crates/podfetch-persistence/src/settings.rs
@@ -23,6 +23,8 @@ diesel::table! {
         use_one_cover_for_all_episodes -> Bool,
         max_parallel_downloads -> Integer,
         sponsorblock_enabled -> Bool,
+        nfo_format -> Text,
+        cover_filename -> Text,
     }
 }
 
@@ -45,6 +47,8 @@ struct SettingEntity {
     use_one_cover_for_all_episodes: bool,
     max_parallel_downloads: i32,
     sponsorblock_enabled: bool,
+    nfo_format: String,
+    cover_filename: String,
 }
 
 impl From<SettingEntity> for Setting {
@@ -66,6 +70,8 @@ impl From<SettingEntity> for Setting {
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
             max_parallel_downloads: value.max_parallel_downloads,
             sponsorblock_enabled: value.sponsorblock_enabled,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }
@@ -89,6 +95,8 @@ impl From<Setting> for SettingEntity {
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
             max_parallel_downloads: value.max_parallel_downloads,
             sponsorblock_enabled: value.sponsorblock_enabled,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }
@@ -151,9 +159,37 @@ impl SettingRepository for DieselSettingsRepository {
                 use_one_cover_for_all_episodes.eq(false),
                 max_parallel_downloads.eq(3),
                 sponsorblock_enabled.eq(true),
+                nfo_format.eq("off"),
+                cover_filename.eq("image"),
             ))
             .execute(&mut conn)
             .map(|_| ())
             .map_err(Into::into)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::db::{database, test_db::setup};
+
+    #[test]
+    fn nfo_format_and_cover_filename_round_trip() {
+        let _guard = setup();
+        let repo = DieselSettingsRepository::new(database());
+        if repo.get_settings().expect("get").is_none() {
+            repo.insert_default_settings().expect("insert default");
+        }
+
+        let mut s = repo.get_settings().expect("get").expect("present");
+        s.nfo_format = "album".to_string();
+        s.cover_filename = "cover".to_string();
+        let updated = repo.update_settings(s).expect("update");
+        assert_eq!(updated.nfo_format, "album");
+        assert_eq!(updated.cover_filename, "cover");
+
+        let reread = repo.get_settings().expect("get").expect("present");
+        assert_eq!(reread.nfo_format, "album");
+        assert_eq!(reread.cover_filename, "cover");
     }
 }

--- a/crates/podfetch-storage/src/path.rs
+++ b/crates/podfetch-storage/src/path.rs
@@ -1,10 +1,11 @@
 pub fn build_podcast_image_paths(
     directory: &str,
     suffix: &str,
+    cover_filename: &str,
     map_to_local_url: impl FnOnce(&str) -> String,
 ) -> (String, String) {
-    let file_path = format!("{directory}/image.{suffix}");
-    let url_path = format!("{}/image.{}", map_to_local_url(directory), suffix);
+    let file_path = format!("{directory}/{cover_filename}.{suffix}");
+    let url_path = format!("{}/{}.{}", map_to_local_url(directory), cover_filename, suffix);
     (file_path, url_path)
 }
 
@@ -36,15 +37,15 @@ mod tests {
 
     #[test]
     fn builds_prefixed_podcast_image_paths() {
-        let result = build_podcast_image_paths("podcasts/test", "png", |directory| {
+        let result = build_podcast_image_paths("podcasts/test", "png", "cover", |directory| {
             format!("/api/files/{directory}")
         });
 
         assert_eq!(
             result,
             (
-                "podcasts/test/image.png".to_string(),
-                "/api/files/podcasts/test/image.png".to_string()
+                "podcasts/test/cover.png".to_string(),
+                "/api/files/podcasts/test/cover.png".to_string()
             )
         );
     }

--- a/crates/podfetch-web/src/controllers/podcast_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_controller.rs
@@ -1217,6 +1217,8 @@ pub mod tests {
             activated: true,
             podcast_prefill: 10,
             use_one_cover_for_all_episodes: false,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let update_resp = ts_server

--- a/crates/podfetch-web/src/controllers/podcast_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_controller.rs
@@ -880,6 +880,8 @@ pub async fn retrieve_podcast_sample_format(
         use_one_cover_for_all_episodes: false,
         max_parallel_downloads: 3,
         sponsorblock_enabled: true,
+        nfo_format: "off".to_string(),
+        cover_filename: "image".to_string(),
     };
     let result = perform_podcast_variable_replacement(settings.into(), podcast, None);
 

--- a/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
@@ -557,7 +557,7 @@ pub async fn retrieve_episode_sample_format(
         nfo_format: "off".to_string(),
         cover_filename: "image".to_string(),
     };
-    let result = perform_episode_variable_replacement(settings.into(), episode, None)?;
+    let result = perform_episode_variable_replacement(settings.into(), episode, None, 1)?;
 
     Ok(result)
 }

--- a/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
@@ -554,6 +554,8 @@ pub async fn retrieve_episode_sample_format(
         use_one_cover_for_all_episodes: false,
         max_parallel_downloads: 3,
         sponsorblock_enabled: true,
+        nfo_format: "off".to_string(),
+        cover_filename: "image".to_string(),
     };
     let result = perform_episode_variable_replacement(settings.into(), episode, None)?;
 

--- a/crates/podfetch-web/src/controllers/settings_controller.rs
+++ b/crates/podfetch-web/src/controllers/settings_controller.rs
@@ -619,6 +619,8 @@ mod tests {
                 use_one_cover_for_all_episodes: false,
                 max_parallel_downloads: 3,
                 sponsorblock_enabled: true,
+                nfo_format: "off".to_string(),
+                cover_filename: "cover".to_string(),
             }),
         )
         .await;

--- a/crates/podfetch-web/src/controllers/settings_controller.rs
+++ b/crates/podfetch-web/src/controllers/settings_controller.rs
@@ -620,7 +620,7 @@ mod tests {
                 max_parallel_downloads: 3,
                 sponsorblock_enabled: true,
                 nfo_format: "off".to_string(),
-                cover_filename: "cover".to_string(),
+                cover_filename: "image".to_string(),
             }),
         )
         .await;

--- a/crates/podfetch-web/src/podcast_settings.rs
+++ b/crates/podfetch-web/src/podcast_settings.rs
@@ -20,6 +20,10 @@ pub struct PodcastSetting {
     pub activated: bool,
     pub podcast_prefill: i32,
     pub use_one_cover_for_all_episodes: bool,
+    #[serde(default = "crate::settings::default_nfo_format")]
+    pub nfo_format: String,
+    #[serde(default = "crate::settings::default_cover_filename")]
+    pub cover_filename: String,
 }
 
 impl From<podfetch_domain::podcast_settings::PodcastSetting> for PodcastSetting {
@@ -40,6 +44,8 @@ impl From<podfetch_domain::podcast_settings::PodcastSetting> for PodcastSetting 
             activated: value.activated,
             podcast_prefill: value.podcast_prefill,
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }
@@ -62,6 +68,8 @@ impl From<PodcastSetting> for podfetch_domain::podcast_settings::PodcastSetting 
             activated: value.activated,
             podcast_prefill: value.podcast_prefill,
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }

--- a/crates/podfetch-web/src/services/download/service.rs
+++ b/crates/podfetch-web/src/services/download/service.rs
@@ -348,6 +348,15 @@ impl DownloadService {
             paths.filename.clone()
         };
 
+        // Jellyfin/Kodi NFO sidecar files (non-fatal). Uses the FINAL media path
+        // so the per-episode .nfo basename matches the audio file even after
+        // Opus transcoding.
+        crate::services::nfo::service::regenerate_for_episode(
+            podcast,
+            &podcast_episode,
+            &final_episode_path,
+        );
+
         PodcastEpisodeService::update_local_paths(
             &podcast_episode.episode_id,
             &paths.image_filename,

--- a/crates/podfetch-web/src/services/download/service.rs
+++ b/crates/podfetch-web/src/services/download/service.rs
@@ -481,29 +481,21 @@ impl DownloadService {
 
         let settings_for_podcast =
             PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
-
-        if let Some(settings_for_podcast) = settings_for_podcast {
-            if settings_for_podcast.episode_numbering {
-                if !podcast_episode.episode_numbering_processed {
-                    tag.set_title(format!("{} - {}", index, &podcast_episode.name));
-                    PodcastEpisodeService::update_episode_numbering_processed(
-                        true,
-                        &podcast_episode.episode_id,
-                    )?;
-                }
-            } else {
-                tag.set_title(&podcast_episode.name);
-                PodcastEpisodeService::update_episode_numbering_processed(
-                    false,
-                    &podcast_episode.episode_id,
-                )?
-            }
-        } else {
-            tag.set_title(&podcast_episode.name);
+        let numbering_enabled = settings_for_podcast
+            .as_ref()
+            .map(|s| s.episode_numbering)
+            .unwrap_or(false);
+        if let Some((title, processed)) = Self::resolve_episode_title(
+            &podcast_episode.name,
+            podcast_episode.episode_numbering_processed,
+            numbering_enabled,
+            index,
+        ) {
+            tag.set_title(title);
             PodcastEpisodeService::update_episode_numbering_processed(
-                false,
+                processed,
                 &podcast_episode.episode_id,
-            )?
+            )?;
         }
 
         if let Some(author) = &podcast.author {
@@ -563,7 +555,28 @@ impl DownloadService {
         let tag = mp4ameta::Tag::read_from_path(&paths.filename);
         match tag {
             Ok(mut tag) => {
-                tag.set_title(&podcast_episode.name);
+                let index = PodcastEpisodeService::get_position_of_episode(
+                    &podcast_episode.date_of_recording,
+                    parse_id(&podcast_episode.podcast_id)?,
+                )?;
+                let settings_for_podcast =
+                    PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
+                let numbering_enabled = settings_for_podcast
+                    .as_ref()
+                    .map(|s| s.episode_numbering)
+                    .unwrap_or(false);
+                if let Some((title, processed)) = Self::resolve_episode_title(
+                    &podcast_episode.name,
+                    podcast_episode.episode_numbering_processed,
+                    numbering_enabled,
+                    index,
+                ) {
+                    tag.set_title(&title);
+                    PodcastEpisodeService::update_episode_numbering_processed(
+                        processed,
+                        &podcast_episode.episode_id,
+                    )?;
+                }
                 tag.set_artist(podcast.clone().author.unwrap_or("Unknown".to_string()));
                 tag.set_album(&podcast.name);
                 tag.set_genre(podcast.clone().keywords.unwrap_or("Unknown".to_string()));
@@ -601,6 +614,26 @@ impl DownloadService {
                 );
                 Ok(())
             }
+        }
+    }
+
+    /// Decide the title to embed and whether to (re)write the
+    /// `episode_numbering_processed` flag. Returns `None` when numbering is on
+    /// and the episode was already processed (leave the existing title alone).
+    pub(crate) fn resolve_episode_title(
+        name: &str,
+        episode_numbering_processed: bool,
+        numbering_enabled: bool,
+        index: usize,
+    ) -> Option<(String, bool)> {
+        if numbering_enabled {
+            if episode_numbering_processed {
+                None
+            } else {
+                Some((format!("{index} - {name}"), true))
+            }
+        } else {
+            Some((name.to_string(), false))
         }
     }
 
@@ -716,6 +749,29 @@ impl DownloadService {
 #[cfg(test)]
 mod tests {
     use super::{DownloadService, FilenameBuilderReturn, Podcast, PodcastEpisode};
+
+    #[test]
+    fn resolve_episode_title_handles_all_numbering_states() {
+        // numbering on, not yet processed -> prefix + mark processed
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", false, true, 5),
+            Some(("5 - Ep".to_string(), true))
+        );
+        // numbering on, already processed -> leave as-is
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", true, true, 5),
+            None
+        );
+        // numbering off -> plain title, mark not-processed
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", false, false, 5),
+            Some(("Ep".to_string(), false))
+        );
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", true, false, 5),
+            Some(("Ep".to_string(), false))
+        );
+    }
 
     #[test]
     fn empty_stored_value_is_treated_as_default_image() {

--- a/crates/podfetch-web/src/services/episode_rescan/service.rs
+++ b/crates/podfetch-web/src/services/episode_rescan/service.rs
@@ -34,6 +34,9 @@ pub struct RescanOptions {
     /// For episodes ingested before SponsorBlock support, the YouTube video id
     /// is backfilled in-memory from the guid/url for this fetch.
     pub refetch_sponsorblock: bool,
+    /// (Re)write NFO files for the episode (and rename the cover) using the
+    /// current settings, without re-downloading audio.
+    pub regenerate_nfo: bool,
 }
 
 impl RescanOptions {
@@ -43,6 +46,7 @@ impl RescanOptions {
             || self.apply_covers
             || self.apply_metadata
             || self.refetch_sponsorblock
+            || self.regenerate_nfo
     }
 }
 
@@ -369,6 +373,11 @@ impl EpisodeRescanService {
             }
         }
 
+        if opts.regenerate_nfo {
+            crate::services::nfo::service::regenerate_for_episode(&podcast, episode, &final_audio_path);
+            crate::services::nfo::service::ensure_cover_filename(&podcast);
+        }
+
         Ok(())
     }
 
@@ -502,6 +511,13 @@ mod tests {
         assert!(
             RescanOptions {
                 apply_metadata: true,
+                ..RescanOptions::default()
+            }
+            .any_enabled()
+        );
+        assert!(
+            RescanOptions {
+                regenerate_nfo: true,
                 ..RescanOptions::default()
             }
             .any_enabled()

--- a/crates/podfetch-web/src/services/file/service.rs
+++ b/crates/podfetch-web/src/services/file/service.rs
@@ -132,9 +132,13 @@ impl FileService {
             .await?
         };
 
+        let cover_filename = uuid::Uuid::parse_str(podcast_id)
+            .map(crate::services::nfo::service::resolve_cover_filename)
+            .unwrap_or_else(|_| "image".to_string());
         let file_path = build_podcast_image_paths(
             podcast_path,
             &image_suffix.0,
+            &cover_filename,
             PodcastEpisodeService::map_to_local_url,
         );
         FileHandleWrapper::write_file_async(

--- a/crates/podfetch-web/src/services/file/service.rs
+++ b/crates/podfetch-web/src/services/file/service.rs
@@ -523,6 +523,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -552,6 +554,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -581,6 +585,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -608,6 +614,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -655,6 +663,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -702,6 +712,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -749,6 +761,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let podcast_episode = PodcastParsed {
@@ -783,6 +797,8 @@ mod tests {
             use_one_cover_for_all_episodes: false,
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "cover".to_string(),
         };
 
         let podcast_episode = PodcastParsed {

--- a/crates/podfetch-web/src/services/file/service.rs
+++ b/crates/podfetch-web/src/services/file/service.rs
@@ -524,7 +524,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -555,7 +555,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -586,7 +586,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let result = perform_replacement(title, settings, None);
@@ -615,7 +615,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -664,7 +664,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -713,7 +713,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let podcast_episode = PodcastEpisode {
@@ -762,7 +762,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let podcast_episode = PodcastParsed {
@@ -798,7 +798,7 @@ mod tests {
             max_parallel_downloads: 3,
             sponsorblock_enabled: true,
             nfo_format: "off".to_string(),
-            cover_filename: "cover".to_string(),
+            cover_filename: "image".to_string(),
         };
 
         let podcast_episode = PodcastParsed {

--- a/crates/podfetch-web/src/services/file/service.rs
+++ b/crates/podfetch-web/src/services/file/service.rs
@@ -330,14 +330,18 @@ pub fn prepare_podcast_episode_title_to_directory(
             return Ok(res_unwrapped);
         }
     }
-    let podcast_settings = PodcastSettingsService::get_settings_for_podcast(
-        uuid::Uuid::parse_str(&podcast_episode.podcast_id)
-            .map_err(|_| CustomError::from(CustomErrorInner::NotFound(ErrorSeverity::Warning)))?,
-    )?;
+    let podcast_uuid = uuid::Uuid::parse_str(&podcast_episode.podcast_id)
+        .map_err(|_| CustomError::from(CustomErrorInner::NotFound(ErrorSeverity::Warning)))?;
+    let podcast_settings = PodcastSettingsService::get_settings_for_podcast(podcast_uuid)?;
+    let episode_number = crate::usecases::podcast_episode::PodcastEpisodeUseCase::get_position_of_episode(
+        &podcast_episode.date_of_recording,
+        podcast_uuid,
+    )? as i64;
     perform_episode_variable_replacement(
         retrieved_settings.into(),
         podcast_episode,
         podcast_settings,
+        episode_number,
     )
 }
 
@@ -345,6 +349,7 @@ pub fn perform_episode_variable_replacement(
     retrieved_settings: Setting,
     podcast_episode: PodcastEpisode,
     podcast_settings: Option<PodcastSetting>,
+    episode_number: i64,
 ) -> Result<String, CustomError> {
     let escaped_episode_title = perform_replacement(
         &podcast_episode.name,
@@ -372,6 +377,7 @@ pub fn perform_episode_variable_replacement(
     let mut vars: HashMap<String, &str> = HashMap::new();
 
     let total_time = podcast_episode.total_time.to_string();
+    let episode_number_str = episode_number.to_string();
     let episode_date = replace_date_of_str(&podcast_episode.date_of_recording);
     // Insert variables
     vars.insert("episodeTitle".to_string(), &escaped_episode_title);
@@ -383,6 +389,7 @@ pub fn perform_episode_variable_replacement(
         &podcast_episode.description,
     );
     vars.insert("episodeDuration".to_string(), &total_time);
+    vars.insert("episodeNumber".to_string(), &episode_number_str);
 
     let fixed_string = episode_format
         .replace("{title}", "{episodeTitle}")
@@ -643,7 +650,7 @@ mod tests {
             youtube_video_id: None,
         };
 
-        let result = perform_episode_variable_replacement(settings, podcast_episode, None);
+        let result = perform_episode_variable_replacement(settings, podcast_episode, None, 1);
         assert_eq!(result.unwrap(), "test123test");
     }
 
@@ -692,7 +699,7 @@ mod tests {
             youtube_video_id: None,
         };
 
-        let result = perform_episode_variable_replacement(settings, podcast_episode, None);
+        let result = perform_episode_variable_replacement(settings, podcast_episode, None, 1);
         assert_eq!(result.unwrap(), "2022MyPodcasttest");
     }
 
@@ -741,8 +748,57 @@ mod tests {
             youtube_video_id: None,
         };
 
-        let result = perform_episode_variable_replacement(settings, podcast_episode, None);
+        let result = perform_episode_variable_replacement(settings, podcast_episode, None, 1);
         assert_eq!(result.unwrap(), "MyPodcast");
+    }
+
+    #[test]
+    #[serial]
+    fn episode_format_supports_episode_number_token() {
+        let settings = Setting {
+            id: uuid::Uuid::nil(),
+            auto_download: false,
+            auto_update: false,
+            auto_cleanup: false,
+            auto_cleanup_days: 0,
+            podcast_format: "{date}{title}".to_string(),
+            episode_format: "{episodeNumber:0>3} - {episodeTitle}".to_string(),
+            replacement_strategy: "replace-with-dash".to_string(),
+            replace_invalid_characters: true,
+            use_existing_filename: false,
+            podcast_prefill: 0,
+            direct_paths: false,
+            auto_transcode_opus: false,
+            use_one_cover_for_all_episodes: false,
+            max_parallel_downloads: 3,
+            sponsorblock_enabled: true,
+            nfo_format: "off".to_string(),
+            cover_filename: "image".to_string(),
+        };
+
+        let podcast_episode = PodcastEpisode {
+            id: uuid::Uuid::nil().to_string(),
+            legacy_id: None,
+            name: "Hello".to_string(),
+            description: "test".to_string(),
+            url: "test".to_string(),
+            guid: "test".to_string(),
+            total_time: 0,
+            date_of_recording: "2022".to_string(),
+            podcast_id: uuid::Uuid::nil().to_string(),
+            file_episode_path: None,
+            file_image_path: None,
+            episode_id: "".to_string(),
+            image_url: "".to_string(),
+            download_time: None,
+            deleted: false,
+            episode_numbering_processed: false,
+            download_location: None,
+            youtube_video_id: None,
+        };
+
+        let result = perform_episode_variable_replacement(settings, podcast_episode, None, 7);
+        assert_eq!(result.unwrap(), "007 - Hello");
     }
 
     #[test]

--- a/crates/podfetch-web/src/services/mod.rs
+++ b/crates/podfetch-web/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod invite;
 pub mod listening_event;
 pub mod login;
 pub mod mopidy;
+pub mod nfo;
 pub mod notification;
 pub mod playlist;
 pub mod podcast;

--- a/crates/podfetch-web/src/services/nfo/builders.rs
+++ b/crates/podfetch-web/src/services/nfo/builders.rs
@@ -1,0 +1,1 @@
+//! NFO XML builders (filled in Task 3).

--- a/crates/podfetch-web/src/services/nfo/builders.rs
+++ b/crates/podfetch-web/src/services/nfo/builders.rs
@@ -92,7 +92,9 @@ pub fn build_episodedetails_nfo(
     write_text_el(&mut w, "episode", Some(&position.to_string()));
     write_text_el(&mut w, "plot", Some(&episode.description));
     write_text_el(&mut w, "aired", aired_date(&episode.date_of_recording).as_deref());
-    write_text_el(&mut w, "runtime", Some(&runtime_minutes(episode.total_time).to_string()));
+    if episode.total_time > 0 {
+        write_text_el(&mut w, "runtime", Some(&runtime_minutes(episode.total_time).to_string()));
+    }
     if let Some(author) = podcast.author.as_deref().filter(|a| !a.is_empty()) {
         w.write_event(Event::Start(BytesStart::new("actor")))
             .expect("start actor");
@@ -205,6 +207,30 @@ mod tests {
         };
         let xml = build_episodedetails_nfo(&p, &episode(), 1);
         assert!(!xml.contains("<actor>"));
+    }
+
+    #[test]
+    fn episodedetails_omits_runtime_when_duration_unknown() {
+        let mut e = episode();
+        e.total_time = 0;
+        let xml = build_episodedetails_nfo(&podcast(), &e, 1);
+        assert!(!xml.contains("<runtime>"));
+    }
+
+    #[test]
+    fn album_omits_absent_optional_fields() {
+        let p = Podcast {
+            name: "Bare Album".to_string(),
+            ..Default::default()
+        };
+        let tracks = vec![(episode(), 1)];
+        let xml = build_album_nfo(&p, &tracks);
+        assert!(xml.contains("<title>Bare Album</title>"));
+        assert!(!xml.contains("<artist>"));
+        assert!(!xml.contains("<genre>"));
+        assert!(!xml.contains("<review>"));
+        // tracks still present
+        assert!(xml.contains("<position>1</position>"));
     }
 
     #[test]

--- a/crates/podfetch-web/src/services/nfo/builders.rs
+++ b/crates/podfetch-web/src/services/nfo/builders.rs
@@ -1,1 +1,225 @@
-//! NFO XML builders (filled in Task 3).
+//! Pure NFO XML builders. Domain types in, XML string out. No DB, no FS.
+
+use podfetch_domain::podcast::Podcast;
+use podfetch_domain::podcast_episode::PodcastEpisode;
+use quick_xml::Writer;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use std::io::Cursor;
+
+type XmlWriter = Writer<Cursor<Vec<u8>>>;
+
+fn new_writer() -> XmlWriter {
+    Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2)
+}
+
+fn finish(writer: XmlWriter) -> String {
+    String::from_utf8(writer.into_inner().into_inner()).expect("xml is valid utf-8")
+}
+
+fn write_decl(w: &mut XmlWriter) {
+    w.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), Some("yes"))))
+        .expect("write decl");
+}
+
+/// Write `<name>text</name>`. No-op when `text` is None or empty. `quick_xml`
+/// escapes the text content (`&`, `<`, `>`, quotes) automatically.
+fn write_text_el(w: &mut XmlWriter, name: &str, text: Option<&str>) {
+    let Some(text) = text.filter(|t| !t.is_empty()) else {
+        return;
+    };
+    w.write_event(Event::Start(BytesStart::new(name)))
+        .expect("start element");
+    w.write_event(Event::Text(BytesText::new(text)))
+        .expect("text");
+    w.write_event(Event::End(BytesEnd::new(name)))
+        .expect("end element");
+}
+
+/// Write `<uniqueid type="podfetch">id</uniqueid>` when `id` is non-empty.
+fn write_uniqueid(w: &mut XmlWriter, id: Option<&str>) {
+    let Some(id) = id.filter(|s| !s.is_empty()) else {
+        return;
+    };
+    let mut el = BytesStart::new("uniqueid");
+    el.push_attribute(("type", "podfetch"));
+    w.write_event(Event::Start(el)).expect("start uniqueid");
+    w.write_event(Event::Text(BytesText::new(id)))
+        .expect("uniqueid text");
+    w.write_event(Event::End(BytesEnd::new("uniqueid")))
+        .expect("end uniqueid");
+}
+
+/// Kodi `<runtime>` is expressed in whole minutes.
+fn runtime_minutes(total_time_secs: i32) -> i64 {
+    ((total_time_secs.max(0) as f64) / 60.0).round() as i64
+}
+
+/// `date_of_recording` is typically ISO-8601 ("2023-09-07T13:09:00"). Take the
+/// `YYYY-MM-DD` prefix (dates are ASCII so byte slicing is char-safe).
+fn aired_date(date_of_recording: &str) -> Option<String> {
+    date_of_recording.get(..10).map(str::to_string)
+}
+
+/// `tvshow.nfo` at the podcast root.
+pub fn build_tvshow_nfo(podcast: &Podcast) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("tvshow")))
+        .expect("start tvshow");
+    write_text_el(&mut w, "title", Some(&podcast.name));
+    write_text_el(&mut w, "plot", podcast.summary.as_deref());
+    write_text_el(&mut w, "studio", podcast.author.as_deref());
+    write_text_el(&mut w, "genre", podcast.keywords.as_deref());
+    write_uniqueid(&mut w, podcast.guid.as_deref());
+    w.write_event(Event::End(BytesEnd::new("tvshow")))
+        .expect("end tvshow");
+    finish(w)
+}
+
+/// Per-episode `<basename>.nfo`.
+pub fn build_episodedetails_nfo(
+    podcast: &Podcast,
+    episode: &PodcastEpisode,
+    position: i64,
+) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("episodedetails")))
+        .expect("start episodedetails");
+    write_text_el(&mut w, "title", Some(&episode.name));
+    write_text_el(&mut w, "showtitle", Some(&podcast.name));
+    write_text_el(&mut w, "season", Some("1"));
+    write_text_el(&mut w, "episode", Some(&position.to_string()));
+    write_text_el(&mut w, "plot", Some(&episode.description));
+    write_text_el(&mut w, "aired", aired_date(&episode.date_of_recording).as_deref());
+    write_text_el(&mut w, "runtime", Some(&runtime_minutes(episode.total_time).to_string()));
+    if let Some(author) = podcast.author.as_deref().filter(|a| !a.is_empty()) {
+        w.write_event(Event::Start(BytesStart::new("actor")))
+            .expect("start actor");
+        write_text_el(&mut w, "name", Some(author));
+        w.write_event(Event::End(BytesEnd::new("actor")))
+            .expect("end actor");
+    }
+    write_uniqueid(&mut w, Some(&episode.guid));
+    w.write_event(Event::End(BytesEnd::new("episodedetails")))
+        .expect("end episodedetails");
+    finish(w)
+}
+
+/// Single `album.nfo` at the podcast root. `tracks` are `(episode, position)`
+/// ordered by date.
+pub fn build_album_nfo(podcast: &Podcast, tracks: &[(PodcastEpisode, i64)]) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("album")))
+        .expect("start album");
+    write_text_el(&mut w, "title", Some(&podcast.name));
+    write_text_el(&mut w, "artist", podcast.author.as_deref());
+    write_text_el(&mut w, "genre", podcast.keywords.as_deref());
+    write_text_el(&mut w, "review", podcast.summary.as_deref());
+    for (episode, position) in tracks {
+        w.write_event(Event::Start(BytesStart::new("track")))
+            .expect("start track");
+        write_text_el(&mut w, "position", Some(&position.to_string()));
+        write_text_el(&mut w, "title", Some(&episode.name));
+        write_text_el(&mut w, "duration", Some(&episode.total_time.to_string()));
+        w.write_event(Event::End(BytesEnd::new("track")))
+            .expect("end track");
+    }
+    w.write_event(Event::End(BytesEnd::new("album")))
+        .expect("end album");
+    finish(w)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn podcast() -> Podcast {
+        Podcast {
+            name: "My Podcast".to_string(),
+            summary: Some("A show about things & stuff".to_string()),
+            author: Some("Jane Host".to_string()),
+            keywords: Some("tech, news".to_string()),
+            guid: Some("podcast-guid-1".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn episode() -> PodcastEpisode {
+        PodcastEpisode {
+            name: "Episode <One>".to_string(),
+            description: "Plot & details".to_string(),
+            date_of_recording: "2023-09-07T13:09:00".to_string(),
+            total_time: 2520, // 42 minutes
+            guid: "episode-guid-1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tvshow_has_expected_fields_and_escapes() {
+        let xml = build_tvshow_nfo(&podcast());
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"));
+        assert!(xml.contains("<title>My Podcast</title>"));
+        assert!(xml.contains("<plot>A show about things &amp; stuff</plot>"));
+        assert!(xml.contains("<studio>Jane Host</studio>"));
+        assert!(xml.contains("<genre>tech, news</genre>"));
+        assert!(xml.contains("<uniqueid type=\"podfetch\">podcast-guid-1</uniqueid>"));
+    }
+
+    #[test]
+    fn tvshow_omits_absent_optional_fields() {
+        let p = Podcast {
+            name: "Bare".to_string(),
+            ..Default::default()
+        };
+        let xml = build_tvshow_nfo(&p);
+        assert!(xml.contains("<title>Bare</title>"));
+        assert!(!xml.contains("<studio>"));
+        assert!(!xml.contains("<plot>"));
+        assert!(!xml.contains("<genre>"));
+        assert!(!xml.contains("<uniqueid"));
+    }
+
+    #[test]
+    fn episodedetails_maps_runtime_minutes_position_and_actor() {
+        let xml = build_episodedetails_nfo(&podcast(), &episode(), 7);
+        assert!(xml.contains("<title>Episode &lt;One&gt;</title>"));
+        assert!(xml.contains("<showtitle>My Podcast</showtitle>"));
+        assert!(xml.contains("<season>1</season>"));
+        assert!(xml.contains("<episode>7</episode>"));
+        assert!(xml.contains("<plot>Plot &amp; details</plot>"));
+        assert!(xml.contains("<aired>2023-09-07</aired>"));
+        assert!(xml.contains("<runtime>42</runtime>"));
+        assert!(xml.contains("<actor>"));
+        assert!(xml.contains("<name>Jane Host</name>"));
+        assert!(xml.contains("<uniqueid type=\"podfetch\">episode-guid-1</uniqueid>"));
+    }
+
+    #[test]
+    fn episodedetails_omits_actor_without_author() {
+        let p = Podcast {
+            name: "P".to_string(),
+            ..Default::default()
+        };
+        let xml = build_episodedetails_nfo(&p, &episode(), 1);
+        assert!(!xml.contains("<actor>"));
+    }
+
+    #[test]
+    fn album_lists_tracks_in_order() {
+        let mut e2 = episode();
+        e2.name = "Episode Two".to_string();
+        e2.total_time = 60;
+        let tracks = vec![(episode(), 1), (e2, 2)];
+        let xml = build_album_nfo(&podcast(), &tracks);
+        assert!(xml.contains("<artist>Jane Host</artist>"));
+        assert!(xml.contains("<review>A show about things &amp; stuff</review>"));
+        let p1 = xml.find("<position>1</position>").expect("track 1");
+        let p2 = xml.find("<position>2</position>").expect("track 2");
+        assert!(p1 < p2, "tracks must be ordered");
+        assert!(xml.contains("<duration>2520</duration>"));
+        assert!(xml.contains("<duration>60</duration>"));
+    }
+}

--- a/crates/podfetch-web/src/services/nfo/mod.rs
+++ b/crates/podfetch-web/src/services/nfo/mod.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+pub mod builders;
+pub mod service;
+
+/// Which NFO layout to emit for a podcast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NfoFormat {
+    #[default]
+    Off,
+    Tvshow,
+    Album,
+}
+
+impl FromStr for NfoFormat {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "tvshow" => Ok(NfoFormat::Tvshow),
+            "album" => Ok(NfoFormat::Album),
+            // "off", "", and any unknown value disable NFO generation.
+            _ => Ok(NfoFormat::Off),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_and_unknown_values() {
+        assert_eq!(NfoFormat::from_str("tvshow"), Ok(NfoFormat::Tvshow));
+        assert_eq!(NfoFormat::from_str("album"), Ok(NfoFormat::Album));
+        assert_eq!(NfoFormat::from_str("off"), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::from_str(""), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::from_str("garbage"), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::default(), NfoFormat::Off);
+    }
+}

--- a/crates/podfetch-web/src/services/nfo/service.rs
+++ b/crates/podfetch-web/src/services/nfo/service.rs
@@ -1,0 +1,1 @@
+//! NFO writer service (filled in Task 4).

--- a/crates/podfetch-web/src/services/nfo/service.rs
+++ b/crates/podfetch-web/src/services/nfo/service.rs
@@ -67,6 +67,7 @@ pub fn nfo_path_for(audio_path: &str) -> String {
 }
 
 fn write_nfo_file(path: &str, xml: &str) {
+    // write_file requires &mut [u8]; the Vec allocation is forced by the storage API.
     let mut bytes = xml.as_bytes().to_vec();
     if let Err(err) = FileHandleWrapper::write_file(
         path,
@@ -179,7 +180,7 @@ pub fn ensure_cover_filename(podcast_entity: &PodcastEntity) {
                     ext
                 );
                 if let Err(err) =
-                    PodcastEpisodeService::update_podcast_image(&podcast_entity.id, &new_url)
+                    PodcastEpisodeService::update_podcast_image(&podcast_entity.directory_id, &new_url)
                 {
                     tracing::warn!("Cover renamed but DB image_url update failed: {err}");
                 }
@@ -205,6 +206,11 @@ mod tests {
         assert_eq!(
             nfo_path_for("podcasts/My.Show/episode"),
             "podcasts/My.Show/episode.nfo"
+        );
+        // dot in both a directory component and the filename
+        assert_eq!(
+            nfo_path_for("podcasts/My.Show/2024-01-01 - Ep.mp3"),
+            "podcasts/My.Show/2024-01-01 - Ep.nfo"
         );
         // windows separators
         assert_eq!(nfo_path_for("podcasts\\x\\audio.opus"), "podcasts\\x\\audio.nfo");

--- a/crates/podfetch-web/src/services/nfo/service.rs
+++ b/crates/podfetch-web/src/services/nfo/service.rs
@@ -1,1 +1,212 @@
-//! NFO writer service (filled in Task 4).
+//! Resolves the NFO format from settings and writes NFO files. All writes are
+//! best-effort: failures are logged, never propagated (must not fail a
+//! download or a settings save).
+
+use super::NfoFormat;
+use super::builders;
+use crate::services::podcast_settings::service::PodcastSettingsService;
+use crate::services::settings::service::SettingsService;
+use crate::usecases::podcast_episode::PodcastEpisodeUseCase as PodcastEpisodeService;
+use common_infrastructure::runtime::ENVIRONMENT_SERVICE;
+use podfetch_domain::podcast::Podcast;
+use podfetch_domain::podcast_episode::PodcastEpisode;
+use podfetch_persistence::podcast::PodcastEntity;
+use podfetch_persistence::podcast_episode::PodcastEpisodeEntity;
+use podfetch_storage::{FileHandleWrapper, FileRequest};
+use std::str::FromStr;
+use uuid::Uuid;
+
+const COVER_CANDIDATES: &[&str] = &["image", "cover", "folder", "poster"];
+
+/// Resolve the effective NFO format: per-podcast override (when activated)
+/// falls back to the global setting.
+pub fn resolve_nfo_format(podcast_id: Uuid) -> NfoFormat {
+    let global = SettingsService::shared()
+        .get_settings()
+        .ok()
+        .flatten()
+        .map(|s| s.nfo_format)
+        .unwrap_or_default();
+    let raw = match PodcastSettingsService::get_settings_for_podcast(podcast_id) {
+        Ok(Some(ps)) if ps.activated => ps.nfo_format,
+        _ => global,
+    };
+    NfoFormat::from_str(&raw).unwrap_or_default()
+}
+
+/// Resolve the effective cover base name (empty -> "image").
+pub fn resolve_cover_filename(podcast_id: Uuid) -> String {
+    let global = SettingsService::shared()
+        .get_settings()
+        .ok()
+        .flatten()
+        .map(|s| s.cover_filename)
+        .unwrap_or_default();
+    let raw = match PodcastSettingsService::get_settings_for_podcast(podcast_id) {
+        Ok(Some(ps)) if ps.activated => ps.cover_filename,
+        _ => global,
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        "image".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Derive the sidecar `.nfo` path from a media file path by swapping its
+/// extension. If the path has no extension, append `.nfo`.
+pub fn nfo_path_for(audio_path: &str) -> String {
+    let last_sep = audio_path.rfind(['/', '\\']);
+    match audio_path.rfind('.') {
+        Some(dot) if last_sep.is_none_or(|sep| dot > sep) => {
+            format!("{}.nfo", &audio_path[..dot])
+        }
+        _ => format!("{audio_path}.nfo"),
+    }
+}
+
+fn write_nfo_file(path: &str, xml: &str) {
+    let mut bytes = xml.as_bytes().to_vec();
+    if let Err(err) = FileHandleWrapper::write_file(
+        path,
+        bytes.as_mut_slice(),
+        &ENVIRONMENT_SERVICE.default_file_handler,
+    ) {
+        tracing::warn!("Failed to write NFO file {path}: {err}");
+    }
+}
+
+/// Generate NFO for one episode (and refresh the podcast-level NFO). Non-fatal.
+/// `audio_path` is the FINAL media path (post-transcode), so the per-episode
+/// `.nfo` basename matches the audio file.
+pub fn regenerate_for_episode(
+    podcast_entity: &PodcastEntity,
+    episode_entity: &PodcastEpisodeEntity,
+    audio_path: &str,
+) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    match resolve_nfo_format(podcast_uuid) {
+        NfoFormat::Off => {}
+        NfoFormat::Tvshow => {
+            let podcast = Podcast::from(podcast_entity.clone());
+            let episode = PodcastEpisode::from(episode_entity.clone());
+            let position = PodcastEpisodeService::get_position_of_episode(
+                &episode.date_of_recording,
+                podcast_uuid,
+            )
+            .unwrap_or(0) as i64;
+            write_nfo_file(
+                &nfo_path_for(audio_path),
+                &builders::build_episodedetails_nfo(&podcast, &episode, position),
+            );
+            write_nfo_file(
+                &format!("{}/tvshow.nfo", podcast_entity.directory_name),
+                &builders::build_tvshow_nfo(&podcast),
+            );
+        }
+        NfoFormat::Album => write_album_nfo(podcast_entity),
+    }
+}
+
+/// Rewrite `album.nfo` from the podcast's full downloaded-episode set. Non-fatal.
+fn write_album_nfo(podcast_entity: &PodcastEntity) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    let podcast = Podcast::from(podcast_entity.clone());
+    let mut episodes = match PodcastEpisodeService::get_episodes_by_podcast_id(podcast_uuid) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::warn!("album.nfo: could not load episodes: {err}");
+            return;
+        }
+    };
+    episodes.retain(|e| e.download_time.is_some());
+    episodes.sort_by(|a, b| a.date_of_recording.cmp(&b.date_of_recording));
+    let tracks: Vec<(PodcastEpisode, i64)> = episodes
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| (PodcastEpisode::from(e), (i as i64) + 1))
+        .collect();
+    write_nfo_file(
+        &format!("{}/album.nfo", podcast_entity.directory_name),
+        &builders::build_album_nfo(&podcast, &tracks),
+    );
+}
+
+/// Rename the on-disk podcast cover to the configured base name when needed.
+/// Best-effort, Local backend only (rename is unsupported on S3).
+pub fn ensure_cover_filename(podcast_entity: &PodcastEntity) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    let target = resolve_cover_filename(podcast_uuid);
+    let dir = &podcast_entity.directory_name;
+    if dir.is_empty() {
+        return;
+    }
+    let Some(ext) = std::path::Path::new(&podcast_entity.image_url)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+    else {
+        return;
+    };
+
+    let fh = &ENVIRONMENT_SERVICE.default_file_handler;
+    let target_path = format!("{dir}/{target}.{ext}");
+    if FileHandleWrapper::path_exists(&target_path, FileRequest::File, fh) {
+        return; // already correct
+    }
+    for cand in COVER_CANDIDATES {
+        if *cand == target {
+            continue;
+        }
+        let cand_path = format!("{dir}/{cand}.{ext}");
+        if !FileHandleWrapper::path_exists(&cand_path, FileRequest::File, fh) {
+            continue;
+        }
+        match FileHandleWrapper::rename_file(&cand_path, &target_path, fh) {
+            Ok(()) => {
+                tracing::info!("Renamed cover {cand_path} -> {target_path}");
+                let new_url = format!(
+                    "{}/{}.{}",
+                    PodcastEpisodeService::map_to_local_url(dir),
+                    target,
+                    ext
+                );
+                if let Err(err) =
+                    PodcastEpisodeService::update_podcast_image(&podcast_entity.id, &new_url)
+                {
+                    tracing::warn!("Cover renamed but DB image_url update failed: {err}");
+                }
+            }
+            Err(err) => tracing::warn!("Cover rename {cand_path} -> {target_path} failed: {err}"),
+        }
+        return;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nfo_path_for;
+
+    #[test]
+    fn nfo_path_swaps_extension_or_appends() {
+        assert_eq!(nfo_path_for("podcasts/x/audio.mp3"), "podcasts/x/audio.nfo");
+        assert_eq!(
+            nfo_path_for("podcasts/My Show/2023-09-07 - Ep.mp3"),
+            "podcasts/My Show/2023-09-07 - Ep.nfo"
+        );
+        // dot only in a directory component -> treat as no extension
+        assert_eq!(
+            nfo_path_for("podcasts/My.Show/episode"),
+            "podcasts/My.Show/episode.nfo"
+        );
+        // windows separators
+        assert_eq!(nfo_path_for("podcasts\\x\\audio.opus"), "podcasts\\x\\audio.nfo");
+    }
+}

--- a/crates/podfetch-web/src/services/podcast_settings/service.rs
+++ b/crates/podfetch-web/src/services/podcast_settings/service.rs
@@ -92,8 +92,16 @@ impl PodcastSettingsService {
                     );
                 }
             }
+            if let Some(audio_path) = episode
+                .file_episode_path
+                .as_deref()
+                .filter(|p| !p.is_empty())
+            {
+                crate::services::nfo::service::regenerate_for_episode(&podcast, &episode, audio_path);
+            }
         }
 
+        crate::services::nfo::service::ensure_cover_filename(&podcast);
         Ok(updated_setting.into())
     }
 }

--- a/crates/podfetch-web/src/services/settings/service.rs
+++ b/crates/podfetch-web/src/services/settings/service.rs
@@ -86,7 +86,7 @@ impl SettingsService {
 
         let transient_setting = build_name_only_setting(&update_settings);
         perform_podcast_variable_replacement(transient_setting.clone(), sample_podcast, None)?;
-        perform_episode_variable_replacement(transient_setting, sample_episode, None)?;
+        perform_episode_variable_replacement(transient_setting, sample_episode, None, 1)?;
         Ok(update_settings)
     }
 }

--- a/crates/podfetch-web/src/services/settings/service.rs
+++ b/crates/podfetch-web/src/services/settings/service.rs
@@ -109,6 +109,8 @@ fn build_name_only_setting(update: &UpdateNameSettings) -> podfetch_domain::sett
         use_one_cover_for_all_episodes: false,
         max_parallel_downloads: 3,
         sponsorblock_enabled: true,
+        nfo_format: "off".to_string(),
+        cover_filename: "image".to_string(),
     }
 }
 

--- a/crates/podfetch-web/src/settings.rs
+++ b/crates/podfetch-web/src/settings.rs
@@ -30,6 +30,12 @@ pub struct Setting {
     /// clients that omit it keep working.
     #[serde(default = "default_sponsorblock_enabled")]
     pub sponsorblock_enabled: bool,
+    /// Defaulted on deserialize so older clients that omit it keep working.
+    #[serde(default = "default_nfo_format")]
+    pub nfo_format: String,
+    /// Defaulted on deserialize so older clients that omit it keep working.
+    #[serde(default = "default_cover_filename")]
+    pub cover_filename: String,
 }
 
 fn default_max_parallel_downloads() -> i32 {
@@ -38,6 +44,14 @@ fn default_max_parallel_downloads() -> i32 {
 
 fn default_sponsorblock_enabled() -> bool {
     true
+}
+
+pub(crate) fn default_nfo_format() -> String {
+    "off".to_string()
+}
+
+pub(crate) fn default_cover_filename() -> String {
+    "image".to_string()
 }
 
 impl From<podfetch_domain::settings::Setting> for Setting {
@@ -59,6 +73,8 @@ impl From<podfetch_domain::settings::Setting> for Setting {
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
             max_parallel_downloads: value.max_parallel_downloads,
             sponsorblock_enabled: value.sponsorblock_enabled,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }
@@ -82,6 +98,8 @@ impl From<Setting> for podfetch_domain::settings::Setting {
             use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,
             max_parallel_downloads: value.max_parallel_downloads,
             sponsorblock_enabled: value.sponsorblock_enabled,
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
         }
     }
 }

--- a/docs/superpowers/plans/2026-06-06-download-options-nfo.md
+++ b/docs/superpowers/plans/2026-06-06-download-options-nfo.md
@@ -1,0 +1,1364 @@
+# Download Options: NFO Files, `{episodeNumber}` Token & Jellyfin Polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add configurable Jellyfin/Kodi `.nfo` sidecar generation, an `{episodeNumber}` filename token, an `.m4a`/`.mp4` episode-numbering fix, and a configurable podcast-cover filename to PodFetch.
+
+**Architecture:** A dedicated `services/nfo` module holds **pure** XML builders (domain types in → XML string out, `quick_xml::Writer`) plus a thin, **non-fatal** writer that resolves the format from settings and places files. It's invoked at three sites: the download path, the per-podcast settings-reapply path, and a new `regenerate_nfo` rescan option. Two new settings columns (`nfo_format`, `cover_filename`) are threaded through the existing global + per-podcast settings stack. Numbering logic shared by the MP3/MP4 tag writers is extracted into one pure helper.
+
+**Tech Stack:** Rust, Diesel (sqlite + postgres via MultiBackend), Axum, `quick_xml` (already a dep), React/TypeScript + `openapi-fetch` (`schema.d.ts` is hand-edited).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-download-options-nfo-design.md`
+
+**Conventions (from repo memory — MUST follow):**
+- Repo methods in `podfetch-persistence` return `PersistenceError`, not `CustomError`.
+- DB tests in `podfetch-persistence` MUST serialize via the crate-wide `crate::db::test_db::setup()` lock (runs migrations + holds a process-wide mutex). Never add a module-local lock.
+- **No `cargo fmt`** (there is no fmt gate; running it churns unrelated files).
+- `schema.d.ts` (ui + mobile) is hand-edited — keep keys ordered to match the surrounding file.
+- Migrations target **sqlite + postgres only** (MySQL is not maintained). Simple `ADD COLUMN`/`DROP COLUMN` need no `metadata.toml` (that's only for table-rebuild migrations).
+- Per-crate `-p` builds and clippy need `--features sqlite` (or `--features postgresql`).
+
+---
+
+## Task 1: Data layer — `nfo_format` + `cover_filename` columns end-to-end
+
+Adds two columns to `settings` and `podcast_settings`, threaded through migrations, the Diesel schema, persistence entities, domain structs, and web DTOs. These are coupled by exhaustive `From` impls, so they land together to reach a compiling state.
+
+**Files:**
+- Create: `migrations/sqlite/2026-06-06-130000_nfo_options/up.sql`
+- Create: `migrations/sqlite/2026-06-06-130000_nfo_options/down.sql`
+- Create: `migrations/postgres/2026-06-06-130000_nfo_options/up.sql`
+- Create: `migrations/postgres/2026-06-06-130000_nfo_options/down.sql`
+- Modify: `crates/podfetch-persistence/src/settings.rs`
+- Modify: `crates/podfetch-persistence/src/podcast_settings.rs`
+- Modify: `crates/podfetch-domain/src/settings.rs`
+- Modify: `crates/podfetch-domain/src/podcast_settings.rs`
+- Modify: `crates/podfetch-web/src/settings.rs`
+- Modify: `crates/podfetch-web/src/podcast_settings.rs`
+
+- [ ] **Step 1: Write the SQLite migration**
+
+`migrations/sqlite/2026-06-06-130000_nfo_options/up.sql`:
+```sql
+ALTER TABLE settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';
+ALTER TABLE podcast_settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE podcast_settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';
+```
+
+`migrations/sqlite/2026-06-06-130000_nfo_options/down.sql`:
+```sql
+ALTER TABLE settings DROP COLUMN nfo_format;
+ALTER TABLE settings DROP COLUMN cover_filename;
+ALTER TABLE podcast_settings DROP COLUMN nfo_format;
+ALTER TABLE podcast_settings DROP COLUMN cover_filename;
+```
+
+- [ ] **Step 2: Write the Postgres migration** (identical SQL)
+
+Create `migrations/postgres/2026-06-06-130000_nfo_options/up.sql` and `down.sql` with the **same** four `ADD COLUMN` / `DROP COLUMN` statements as Step 1.
+
+- [ ] **Step 3: Add columns to the `settings` Diesel schema + entity** (`crates/podfetch-persistence/src/settings.rs`)
+
+In the `diesel::table! { settings ... }` block, append after `sponsorblock_enabled -> Bool,`:
+```rust
+        nfo_format -> Text,
+        cover_filename -> Text,
+```
+In `struct SettingEntity`, append after `sponsorblock_enabled: bool,`:
+```rust
+    nfo_format: String,
+    cover_filename: String,
+```
+In `impl From<SettingEntity> for Setting`, append after `sponsorblock_enabled: value.sponsorblock_enabled,`:
+```rust
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
+```
+In `impl From<Setting> for SettingEntity`, append after `sponsorblock_enabled: value.sponsorblock_enabled,`:
+```rust
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
+```
+In `insert_default_settings`, append to the `.values((...))` tuple after `sponsorblock_enabled.eq(true),`:
+```rust
+                nfo_format.eq("off"),
+                cover_filename.eq("image"),
+```
+
+- [ ] **Step 4: Add columns to the `podcast_settings` Diesel schema + entity** (`crates/podfetch-persistence/src/podcast_settings.rs`)
+
+In the `diesel::table! { podcast_settings ... }` block, append after `use_one_cover_for_all_episodes -> Bool,`:
+```rust
+        nfo_format -> Text,
+        cover_filename -> Text,
+```
+In `struct PodcastSettingEntity`, append after `use_one_cover_for_all_episodes: bool,`:
+```rust
+    nfo_format: String,
+    cover_filename: String,
+```
+In **both** `From` impls (`From<PodcastSettingEntity> for PodcastSetting` and `From<PodcastSetting> for PodcastSettingEntity`), append after `use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,`:
+```rust
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
+```
+
+- [ ] **Step 5: Add fields to the domain structs**
+
+`crates/podfetch-domain/src/settings.rs` — in `struct Setting`, append after `pub sponsorblock_enabled: bool,`:
+```rust
+    /// Jellyfin/Kodi NFO format: "off" | "tvshow" | "album".
+    pub nfo_format: String,
+    /// Base name of the podcast cover file (default "image").
+    pub cover_filename: String,
+```
+`crates/podfetch-domain/src/podcast_settings.rs` — in `struct PodcastSetting`, append after `pub use_one_cover_for_all_episodes: bool,`:
+```rust
+    pub nfo_format: String,
+    pub cover_filename: String,
+```
+
+- [ ] **Step 6: Add fields to the web DTOs with serde defaults**
+
+`crates/podfetch-web/src/settings.rs` — in `struct Setting`, append after the `sponsorblock_enabled` field:
+```rust
+    /// Defaulted on deserialize so older clients that omit it keep working.
+    #[serde(default = "default_nfo_format")]
+    pub nfo_format: String,
+    /// Defaulted on deserialize so older clients that omit it keep working.
+    #[serde(default = "default_cover_filename")]
+    pub cover_filename: String,
+```
+Add the default fns next to `default_sponsorblock_enabled`:
+```rust
+fn default_nfo_format() -> String {
+    "off".to_string()
+}
+
+fn default_cover_filename() -> String {
+    "image".to_string()
+}
+```
+In **both** `From` impls in this file (`From<domain::Setting> for Setting` and `From<Setting> for domain::Setting`), append after the `sponsorblock_enabled: value.sponsorblock_enabled,` line:
+```rust
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
+```
+
+`crates/podfetch-web/src/podcast_settings.rs` — in `struct PodcastSetting`, append after `pub use_one_cover_for_all_episodes: bool,`:
+```rust
+    #[serde(default = "crate::settings::default_nfo_format")]
+    pub nfo_format: String,
+    #[serde(default = "crate::settings::default_cover_filename")]
+    pub cover_filename: String,
+```
+Make the two default fns in `crates/podfetch-web/src/settings.rs` `pub(crate)` (change `fn default_nfo_format` → `pub(crate) fn default_nfo_format`, same for `default_cover_filename`) so `podcast_settings.rs` can reference them.
+In **both** `From` impls in `podcast_settings.rs`, append after `use_one_cover_for_all_episodes: value.use_one_cover_for_all_episodes,`:
+```rust
+            nfo_format: value.nfo_format,
+            cover_filename: value.cover_filename,
+```
+
+- [ ] **Step 7: Write the persistence round-trip test** (`crates/podfetch-persistence/src/settings.rs`)
+
+Append at the end of the file:
+```rust
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+    use crate::db::{database, test_db::setup};
+
+    #[test]
+    fn nfo_format_and_cover_filename_round_trip() {
+        let _guard = setup();
+        let repo = DieselSettingsRepository::new(database());
+        if repo.get_settings().expect("get").is_none() {
+            repo.insert_default_settings().expect("insert default");
+        }
+
+        let mut s = repo.get_settings().expect("get").expect("present");
+        s.nfo_format = "album".to_string();
+        s.cover_filename = "cover".to_string();
+        let updated = repo.update_settings(s).expect("update");
+        assert_eq!(updated.nfo_format, "album");
+        assert_eq!(updated.cover_filename, "cover");
+
+        let reread = repo.get_settings().expect("get").expect("present");
+        assert_eq!(reread.nfo_format, "album");
+        assert_eq!(reread.cover_filename, "cover");
+    }
+}
+```
+
+- [ ] **Step 8: Build to verify migrations + schema compile, then run the test**
+
+Run: `cargo build -p podfetch-persistence --features sqlite`
+Expected: PASS (the embedded migrations are validated against the schema at build time).
+
+Run: `cargo test -p podfetch-persistence --features sqlite nfo_format_and_cover_filename_round_trip -- --nocapture`
+Expected: PASS.
+
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS (proves every `From` impl across domain/persistence/web maps the new fields). If the compiler reports a missing field at another struct-literal/`From` site, add `nfo_format`/`cover_filename` there with `"off"`/`"image"` (or pass-through).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add migrations crates/podfetch-persistence/src/settings.rs crates/podfetch-persistence/src/podcast_settings.rs crates/podfetch-domain/src/settings.rs crates/podfetch-domain/src/podcast_settings.rs crates/podfetch-web/src/settings.rs crates/podfetch-web/src/podcast_settings.rs
+git commit -m "feat(download-options): add nfo_format + cover_filename settings columns (#315)"
+```
+
+---
+
+## Task 2: `NfoFormat` enum + module skeleton
+
+**Files:**
+- Create: `crates/podfetch-web/src/services/nfo/mod.rs`
+- Modify: `crates/podfetch-web/src/services/mod.rs` (register `pub mod nfo;`)
+
+- [ ] **Step 1: Write the failing test** in `crates/podfetch-web/src/services/nfo/mod.rs`
+
+```rust
+use std::str::FromStr;
+
+pub mod builders;
+pub mod service;
+
+/// Which NFO layout to emit for a podcast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NfoFormat {
+    #[default]
+    Off,
+    Tvshow,
+    Album,
+}
+
+impl FromStr for NfoFormat {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "tvshow" => Ok(NfoFormat::Tvshow),
+            "album" => Ok(NfoFormat::Album),
+            // "off", "", and any unknown value disable NFO generation.
+            _ => Ok(NfoFormat::Off),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_and_unknown_values() {
+        assert_eq!(NfoFormat::from_str("tvshow"), Ok(NfoFormat::Tvshow));
+        assert_eq!(NfoFormat::from_str("album"), Ok(NfoFormat::Album));
+        assert_eq!(NfoFormat::from_str("off"), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::from_str(""), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::from_str("garbage"), Ok(NfoFormat::Off));
+        assert_eq!(NfoFormat::default(), NfoFormat::Off);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** in `crates/podfetch-web/src/services/mod.rs`
+
+Add (in alphabetical position among the existing `pub mod` lines):
+```rust
+pub mod nfo;
+```
+
+> Note: `builders.rs` and `service.rs` are created in Tasks 3 and 4. Until then this won't compile, so create empty stub files now to keep the tree building:
+> - `crates/podfetch-web/src/services/nfo/builders.rs` containing only a doc comment line `//! NFO XML builders (filled in Task 3).`
+> - `crates/podfetch-web/src/services/nfo/service.rs` containing only `//! NFO writer service (filled in Task 4).`
+
+- [ ] **Step 3: Run the test**
+
+Run: `cargo test -p podfetch-web --features sqlite nfo::tests::parses_known_and_unknown_values`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/nfo crates/podfetch-web/src/services/mod.rs
+git commit -m "feat(nfo): add NfoFormat enum + module skeleton (#315)"
+```
+
+---
+
+## Task 3: Pure NFO builders
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/nfo/builders.rs`
+
+- [ ] **Step 1: Write the builders + helpers**
+
+Replace the stub content of `crates/podfetch-web/src/services/nfo/builders.rs` with:
+```rust
+//! Pure NFO XML builders. Domain types in, XML string out. No DB, no FS.
+
+use podfetch_domain::podcast::Podcast;
+use podfetch_domain::podcast_episode::PodcastEpisode;
+use quick_xml::Writer;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use std::io::Cursor;
+
+type XmlWriter = Writer<Cursor<Vec<u8>>>;
+
+fn new_writer() -> XmlWriter {
+    Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2)
+}
+
+fn finish(writer: XmlWriter) -> String {
+    String::from_utf8(writer.into_inner().into_inner()).expect("xml is valid utf-8")
+}
+
+fn write_decl(w: &mut XmlWriter) {
+    w.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), Some("yes"))))
+        .expect("write decl");
+}
+
+/// Write `<name>text</name>`. No-op when `text` is None or empty. `quick_xml`
+/// escapes the text content (`&`, `<`, `>`, quotes) automatically.
+fn write_text_el(w: &mut XmlWriter, name: &str, text: Option<&str>) {
+    let Some(text) = text.filter(|t| !t.is_empty()) else {
+        return;
+    };
+    w.write_event(Event::Start(BytesStart::new(name)))
+        .expect("start element");
+    w.write_event(Event::Text(BytesText::new(text)))
+        .expect("text");
+    w.write_event(Event::End(BytesEnd::new(name)))
+        .expect("end element");
+}
+
+/// Write `<uniqueid type="podfetch">id</uniqueid>` when `id` is non-empty.
+fn write_uniqueid(w: &mut XmlWriter, id: Option<&str>) {
+    let Some(id) = id.filter(|s| !s.is_empty()) else {
+        return;
+    };
+    let mut el = BytesStart::new("uniqueid");
+    el.push_attribute(("type", "podfetch"));
+    w.write_event(Event::Start(el)).expect("start uniqueid");
+    w.write_event(Event::Text(BytesText::new(id)))
+        .expect("uniqueid text");
+    w.write_event(Event::End(BytesEnd::new("uniqueid")))
+        .expect("end uniqueid");
+}
+
+/// Kodi `<runtime>` is expressed in whole minutes.
+fn runtime_minutes(total_time_secs: i32) -> i64 {
+    ((total_time_secs.max(0) as f64) / 60.0).round() as i64
+}
+
+/// `date_of_recording` is typically ISO-8601 ("2023-09-07T13:09:00"). Take the
+/// `YYYY-MM-DD` prefix (dates are ASCII so byte slicing is char-safe).
+fn aired_date(date_of_recording: &str) -> Option<String> {
+    date_of_recording.get(..10).map(str::to_string)
+}
+
+/// `tvshow.nfo` at the podcast root.
+pub fn build_tvshow_nfo(podcast: &Podcast) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("tvshow")))
+        .expect("start tvshow");
+    write_text_el(&mut w, "title", Some(&podcast.name));
+    write_text_el(&mut w, "plot", podcast.summary.as_deref());
+    write_text_el(&mut w, "studio", podcast.author.as_deref());
+    write_text_el(&mut w, "genre", podcast.keywords.as_deref());
+    write_uniqueid(&mut w, podcast.guid.as_deref());
+    w.write_event(Event::End(BytesEnd::new("tvshow")))
+        .expect("end tvshow");
+    finish(w)
+}
+
+/// Per-episode `<basename>.nfo`.
+pub fn build_episodedetails_nfo(
+    podcast: &Podcast,
+    episode: &PodcastEpisode,
+    position: i64,
+) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("episodedetails")))
+        .expect("start episodedetails");
+    write_text_el(&mut w, "title", Some(&episode.name));
+    write_text_el(&mut w, "showtitle", Some(&podcast.name));
+    write_text_el(&mut w, "season", Some("1"));
+    write_text_el(&mut w, "episode", Some(&position.to_string()));
+    write_text_el(&mut w, "plot", Some(&episode.description));
+    write_text_el(&mut w, "aired", aired_date(&episode.date_of_recording).as_deref());
+    write_text_el(&mut w, "runtime", Some(&runtime_minutes(episode.total_time).to_string()));
+    if let Some(author) = podcast.author.as_deref().filter(|a| !a.is_empty()) {
+        w.write_event(Event::Start(BytesStart::new("actor")))
+            .expect("start actor");
+        write_text_el(&mut w, "name", Some(author));
+        w.write_event(Event::End(BytesEnd::new("actor")))
+            .expect("end actor");
+    }
+    write_uniqueid(&mut w, Some(&episode.guid));
+    w.write_event(Event::End(BytesEnd::new("episodedetails")))
+        .expect("end episodedetails");
+    finish(w)
+}
+
+/// Single `album.nfo` at the podcast root. `tracks` are `(episode, position)`
+/// ordered by date.
+pub fn build_album_nfo(podcast: &Podcast, tracks: &[(PodcastEpisode, i64)]) -> String {
+    let mut w = new_writer();
+    write_decl(&mut w);
+    w.write_event(Event::Start(BytesStart::new("album")))
+        .expect("start album");
+    write_text_el(&mut w, "title", Some(&podcast.name));
+    write_text_el(&mut w, "artist", podcast.author.as_deref());
+    write_text_el(&mut w, "genre", podcast.keywords.as_deref());
+    write_text_el(&mut w, "review", podcast.summary.as_deref());
+    for (episode, position) in tracks {
+        w.write_event(Event::Start(BytesStart::new("track")))
+            .expect("start track");
+        write_text_el(&mut w, "position", Some(&position.to_string()));
+        write_text_el(&mut w, "title", Some(&episode.name));
+        write_text_el(&mut w, "duration", Some(&episode.total_time.to_string()));
+        w.write_event(Event::End(BytesEnd::new("track")))
+            .expect("end track");
+    }
+    w.write_event(Event::End(BytesEnd::new("album")))
+        .expect("end album");
+    finish(w)
+}
+```
+
+- [ ] **Step 2: Write the tests** (append to `builders.rs`)
+
+These assert structure/escaping/omission rather than exact whitespace (indentation is a `quick_xml` impl detail), so they're deterministic.
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn podcast() -> Podcast {
+        Podcast {
+            name: "My Podcast".to_string(),
+            summary: Some("A show about things & stuff".to_string()),
+            author: Some("Jane Host".to_string()),
+            keywords: Some("tech, news".to_string()),
+            guid: Some("podcast-guid-1".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn episode() -> PodcastEpisode {
+        PodcastEpisode {
+            name: "Episode <One>".to_string(),
+            description: "Plot & details".to_string(),
+            date_of_recording: "2023-09-07T13:09:00".to_string(),
+            total_time: 2520, // 42 minutes
+            guid: "episode-guid-1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tvshow_has_expected_fields_and_escapes() {
+        let xml = build_tvshow_nfo(&podcast());
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"));
+        assert!(xml.contains("<title>My Podcast</title>"));
+        assert!(xml.contains("<plot>A show about things &amp; stuff</plot>"));
+        assert!(xml.contains("<studio>Jane Host</studio>"));
+        assert!(xml.contains("<genre>tech, news</genre>"));
+        assert!(xml.contains("<uniqueid type=\"podfetch\">podcast-guid-1</uniqueid>"));
+    }
+
+    #[test]
+    fn tvshow_omits_absent_optional_fields() {
+        let p = Podcast {
+            name: "Bare".to_string(),
+            ..Default::default()
+        };
+        let xml = build_tvshow_nfo(&p);
+        assert!(xml.contains("<title>Bare</title>"));
+        assert!(!xml.contains("<studio>"));
+        assert!(!xml.contains("<plot>"));
+        assert!(!xml.contains("<genre>"));
+        assert!(!xml.contains("<uniqueid"));
+    }
+
+    #[test]
+    fn episodedetails_maps_runtime_minutes_position_and_actor() {
+        let xml = build_episodedetails_nfo(&podcast(), &episode(), 7);
+        assert!(xml.contains("<title>Episode &lt;One&gt;</title>"));
+        assert!(xml.contains("<showtitle>My Podcast</showtitle>"));
+        assert!(xml.contains("<season>1</season>"));
+        assert!(xml.contains("<episode>7</episode>"));
+        assert!(xml.contains("<plot>Plot &amp; details</plot>"));
+        assert!(xml.contains("<aired>2023-09-07</aired>"));
+        assert!(xml.contains("<runtime>42</runtime>"));
+        assert!(xml.contains("<actor>"));
+        assert!(xml.contains("<name>Jane Host</name>"));
+        assert!(xml.contains("<uniqueid type=\"podfetch\">episode-guid-1</uniqueid>"));
+    }
+
+    #[test]
+    fn episodedetails_omits_actor_without_author() {
+        let p = Podcast {
+            name: "P".to_string(),
+            ..Default::default()
+        };
+        let xml = build_episodedetails_nfo(&p, &episode(), 1);
+        assert!(!xml.contains("<actor>"));
+    }
+
+    #[test]
+    fn album_lists_tracks_in_order() {
+        let mut e2 = episode();
+        e2.name = "Episode Two".to_string();
+        e2.total_time = 60;
+        let tracks = vec![(episode(), 1), (e2, 2)];
+        let xml = build_album_nfo(&podcast(), &tracks);
+        assert!(xml.contains("<artist>Jane Host</artist>"));
+        assert!(xml.contains("<review>A show about things &amp; stuff</review>"));
+        let p1 = xml.find("<position>1</position>").expect("track 1");
+        let p2 = xml.find("<position>2</position>").expect("track 2");
+        assert!(p1 < p2, "tracks must be ordered");
+        assert!(xml.contains("<duration>2520</duration>"));
+        assert!(xml.contains("<duration>60</duration>"));
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test -p podfetch-web --features sqlite nfo::builders`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/nfo/builders.rs
+git commit -m "feat(nfo): pure tvshow/episodedetails/album XML builders (#315)"
+```
+
+---
+
+## Task 4: NFO writer service (resolution, path derivation, file writing)
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/nfo/service.rs`
+
+- [ ] **Step 1: Write the service**
+
+Replace the stub content of `crates/podfetch-web/src/services/nfo/service.rs` with:
+```rust
+//! Resolves the NFO format from settings and writes NFO files. All writes are
+//! best-effort: failures are logged, never propagated (must not fail a
+//! download or a settings save).
+
+use super::NfoFormat;
+use super::builders;
+use crate::services::file::service::FileService;
+use crate::services::podcast_settings::service::PodcastSettingsService;
+use crate::services::settings::service::SettingsService;
+use crate::usecases::podcast_episode::PodcastEpisodeUseCase as PodcastEpisodeService;
+use common_infrastructure::runtime::ENVIRONMENT_SERVICE;
+use podfetch_domain::podcast::Podcast;
+use podfetch_domain::podcast_episode::PodcastEpisode;
+use podfetch_persistence::podcast::PodcastEntity;
+use podfetch_persistence::podcast_episode::PodcastEpisodeEntity;
+use podfetch_storage::{FileHandleWrapper, FileRequest};
+use std::str::FromStr;
+use uuid::Uuid;
+
+const COVER_CANDIDATES: &[&str] = &["image", "cover", "folder", "poster"];
+
+/// Resolve the effective NFO format: per-podcast override (when activated)
+/// falls back to the global setting.
+pub fn resolve_nfo_format(podcast_id: Uuid) -> NfoFormat {
+    let global = SettingsService::shared()
+        .get_settings()
+        .ok()
+        .flatten()
+        .map(|s| s.nfo_format)
+        .unwrap_or_default();
+    let raw = match PodcastSettingsService::get_settings_for_podcast(podcast_id) {
+        Ok(Some(ps)) if ps.activated => ps.nfo_format,
+        _ => global,
+    };
+    NfoFormat::from_str(&raw).unwrap_or_default()
+}
+
+/// Resolve the effective cover base name (empty → "image").
+pub fn resolve_cover_filename(podcast_id: Uuid) -> String {
+    let global = SettingsService::shared()
+        .get_settings()
+        .ok()
+        .flatten()
+        .map(|s| s.cover_filename)
+        .unwrap_or_default();
+    let raw = match PodcastSettingsService::get_settings_for_podcast(podcast_id) {
+        Ok(Some(ps)) if ps.activated => ps.cover_filename,
+        _ => global,
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        "image".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Derive the sidecar `.nfo` path from a media file path by swapping its
+/// extension. If the path has no extension, append `.nfo`.
+pub fn nfo_path_for(audio_path: &str) -> String {
+    let last_sep = audio_path.rfind(['/', '\\']);
+    match audio_path.rfind('.') {
+        Some(dot) if last_sep.map_or(true, |sep| dot > sep) => {
+            format!("{}.nfo", &audio_path[..dot])
+        }
+        _ => format!("{audio_path}.nfo"),
+    }
+}
+
+fn write_nfo_file(path: &str, xml: &str) {
+    let mut bytes = xml.as_bytes().to_vec();
+    if let Err(err) = FileHandleWrapper::write_file(
+        path,
+        bytes.as_mut_slice(),
+        &ENVIRONMENT_SERVICE.default_file_handler,
+    ) {
+        tracing::warn!("Failed to write NFO file {path}: {err}");
+    }
+}
+
+/// Generate NFO for one episode (and refresh the podcast-level NFO). Non-fatal.
+/// `audio_path` is the FINAL media path (post-transcode), so the per-episode
+/// `.nfo` basename matches the audio file.
+pub fn regenerate_for_episode(
+    podcast_entity: &PodcastEntity,
+    episode_entity: &PodcastEpisodeEntity,
+    audio_path: &str,
+) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    match resolve_nfo_format(podcast_uuid) {
+        NfoFormat::Off => {}
+        NfoFormat::Tvshow => {
+            let podcast = Podcast::from(podcast_entity.clone());
+            let episode = PodcastEpisode::from(episode_entity.clone());
+            let position = PodcastEpisodeService::get_position_of_episode(
+                &episode.date_of_recording,
+                podcast_uuid,
+            )
+            .unwrap_or(0) as i64;
+            write_nfo_file(
+                &nfo_path_for(audio_path),
+                &builders::build_episodedetails_nfo(&podcast, &episode, position),
+            );
+            write_nfo_file(
+                &format!("{}/tvshow.nfo", podcast_entity.directory_name),
+                &builders::build_tvshow_nfo(&podcast),
+            );
+        }
+        NfoFormat::Album => write_album_nfo(podcast_entity),
+    }
+}
+
+/// Rewrite `album.nfo` from the podcast's full downloaded-episode set. Non-fatal.
+fn write_album_nfo(podcast_entity: &PodcastEntity) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    let podcast = Podcast::from(podcast_entity.clone());
+    let mut episodes = match PodcastEpisodeService::get_episodes_by_podcast_id(podcast_uuid) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::warn!("album.nfo: could not load episodes: {err}");
+            return;
+        }
+    };
+    episodes.retain(|e| e.download_time.is_some());
+    episodes.sort_by(|a, b| a.date_of_recording.cmp(&b.date_of_recording));
+    let tracks: Vec<(PodcastEpisode, i64)> = episodes
+        .into_iter()
+        .enumerate()
+        .map(|(i, e)| (PodcastEpisode::from(e), (i as i64) + 1))
+        .collect();
+    write_nfo_file(
+        &format!("{}/album.nfo", podcast_entity.directory_name),
+        &builders::build_album_nfo(&podcast, &tracks),
+    );
+}
+
+/// Rename the on-disk podcast cover to the configured base name when needed.
+/// Best-effort, Local backend only (rename is unsupported on S3).
+pub fn ensure_cover_filename(podcast_entity: &PodcastEntity) {
+    let Ok(podcast_uuid) = Uuid::parse_str(&podcast_entity.id) else {
+        return;
+    };
+    let target = resolve_cover_filename(podcast_uuid);
+    let dir = &podcast_entity.directory_name;
+    if dir.is_empty() {
+        return;
+    }
+    let Some(ext) = std::path::Path::new(&podcast_entity.image_url)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+    else {
+        return;
+    };
+
+    let fh = &ENVIRONMENT_SERVICE.default_file_handler;
+    let target_path = format!("{dir}/{target}.{ext}");
+    if FileHandleWrapper::path_exists(&target_path, FileRequest::File, fh) {
+        return; // already correct
+    }
+    for cand in COVER_CANDIDATES {
+        if *cand == target {
+            continue;
+        }
+        let cand_path = format!("{dir}/{cand}.{ext}");
+        if !FileHandleWrapper::path_exists(&cand_path, FileRequest::File, fh) {
+            continue;
+        }
+        match FileHandleWrapper::rename_file(&cand_path, &target_path, fh) {
+            Ok(()) => {
+                tracing::info!("Renamed cover {cand_path} -> {target_path}");
+                let new_url = format!(
+                    "{}/{}.{}",
+                    PodcastEpisodeService::map_to_local_url(dir),
+                    target,
+                    ext
+                );
+                if let Err(err) =
+                    PodcastEpisodeService::update_podcast_image(&podcast_entity.id, &new_url)
+                {
+                    tracing::warn!("Cover renamed but DB image_url update failed: {err}");
+                }
+            }
+            Err(err) => tracing::warn!("Cover rename {cand_path} -> {target_path} failed: {err}"),
+        }
+        return;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nfo_path_for;
+
+    #[test]
+    fn nfo_path_swaps_extension_or_appends() {
+        assert_eq!(nfo_path_for("podcasts/x/audio.mp3"), "podcasts/x/audio.nfo");
+        assert_eq!(
+            nfo_path_for("podcasts/My Show/2023-09-07 - Ep.mp3"),
+            "podcasts/My Show/2023-09-07 - Ep.nfo"
+        );
+        // dot only in a directory component → treat as no extension
+        assert_eq!(
+            nfo_path_for("podcasts/My.Show/episode"),
+            "podcasts/My.Show/episode.nfo"
+        );
+        // windows separators
+        assert_eq!(nfo_path_for("podcasts\\x\\audio.opus"), "podcasts\\x\\audio.nfo");
+    }
+}
+```
+
+> **Note on `FileService` import:** it is imported above only if a later step needs it; if `cargo` warns it is unused, remove the `use crate::services::file::service::FileService;` line. (It is listed defensively because the cover URL/local-path helpers live near there.) Prefer removing unused imports over `#[allow]`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p podfetch-web --features sqlite nfo::service::tests::nfo_path_swaps_extension_or_appends`
+Expected: PASS.
+
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS. (Confirms `get_episodes_by_podcast_id`, `get_position_of_episode`, `map_to_local_url`, `update_podcast_image` signatures match. If any differ, adjust the call — these are existing `PodcastEpisodeUseCase` methods.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/nfo/service.rs
+git commit -m "feat(nfo): writer service (resolve format, path derivation, cover rename) (#315)"
+```
+
+---
+
+## Task 5: Configurable cover filename for new downloads
+
+**Files:**
+- Modify: `crates/podfetch-storage/src/path.rs`
+- Modify: `crates/podfetch-web/src/services/file/service.rs`
+
+- [ ] **Step 1: Update the failing test + signature** in `crates/podfetch-storage/src/path.rs`
+
+Change `build_podcast_image_paths` to take a `cover_filename`:
+```rust
+pub fn build_podcast_image_paths(
+    directory: &str,
+    suffix: &str,
+    cover_filename: &str,
+    map_to_local_url: impl FnOnce(&str) -> String,
+) -> (String, String) {
+    let file_path = format!("{directory}/{cover_filename}.{suffix}");
+    let url_path = format!("{}/{}.{}", map_to_local_url(directory), cover_filename, suffix);
+    (file_path, url_path)
+}
+```
+Update the existing test `builds_prefixed_podcast_image_paths` to pass the new arg and assert the configured name:
+```rust
+    #[test]
+    fn builds_prefixed_podcast_image_paths() {
+        let result = build_podcast_image_paths("podcasts/test", "png", "cover", |directory| {
+            format!("/api/files/{directory}")
+        });
+
+        assert_eq!(
+            result,
+            (
+                "podcasts/test/cover.png".to_string(),
+                "/api/files/podcasts/test/cover.png".to_string()
+            )
+        );
+    }
+```
+
+- [ ] **Step 2: Run the storage test (expect FAIL until callers compile, then PASS)**
+
+Run: `cargo test -p podfetch-storage --features sqlite build_podcast_image_paths`
+Expected: compile error in `podfetch-web` callers is fine at the crate level; run the storage crate test in isolation — it should PASS (storage crate has no caller of the new signature besides its own test).
+
+- [ ] **Step 3: Update the caller** in `crates/podfetch-web/src/services/file/service.rs`
+
+In `download_podcast_image`, resolve the cover name from settings and pass it. Replace the `build_podcast_image_paths(...)` call (currently around line 135) with:
+```rust
+        let cover_filename = Uuid::parse_str(podcast_id)
+            .map(crate::services::nfo::service::resolve_cover_filename)
+            .unwrap_or_else(|_| "image".to_string());
+        let file_path = build_podcast_image_paths(
+            podcast_path,
+            &image_suffix.0,
+            &cover_filename,
+            PodcastEpisodeService::map_to_local_url,
+        );
+```
+If `uuid::Uuid` is not already imported in this file, add `use uuid::Uuid;` at the top.
+
+- [ ] **Step 4: Find and update any other callers**
+
+Run: `rg -n "build_podcast_image_paths\(" crates --glob '!**/path.rs'`
+For each match, insert the cover-name argument (resolve via `crate::services::nfo::service::resolve_cover_filename(podcast_uuid)` where a podcast UUID is in scope, else `"image"`). Show the change matches the Step 3 shape.
+
+- [ ] **Step 5: Build + test**
+
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS.
+Run: `cargo test -p podfetch-storage --features sqlite build_podcast_image_paths`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/podfetch-storage/src/path.rs crates/podfetch-web/src/services/file/service.rs
+git commit -m "feat(download-options): configurable cover filename for new downloads (#315)"
+```
+
+---
+
+## Task 6: `{episodeNumber}` filename token
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/file/service.rs`
+- Modify: `crates/podfetch-web/src/controllers/podcast_episode_controller.rs`
+- Modify: `crates/podfetch-web/src/services/settings/service.rs`
+
+- [ ] **Step 1: Write a failing test** in `crates/podfetch-web/src/services/file/service.rs` (the existing `#[cfg(test)] mod tests`)
+
+```rust
+    #[test]
+    fn episode_format_supports_episode_number_token() {
+        let mut settings = test_settings(); // existing helper used by sibling tests
+        settings.episode_format = "{episodeNumber:0>3} - {episodeTitle}".to_string();
+        let mut episode = test_episode(); // existing helper
+        episode.name = "Hello".to_string();
+        let result =
+            perform_episode_variable_replacement(settings, episode, None, 7).unwrap();
+        assert_eq!(result, "007 - Hello");
+    }
+```
+> If the sibling tests construct `Setting`/`PodcastEpisode` inline rather than via helpers, mirror their exact construction here instead of `test_settings()`/`test_episode()`.
+
+- [ ] **Step 2: Add the parameter + token** to `perform_episode_variable_replacement`
+
+Change the signature (line 340) to add a trailing param:
+```rust
+pub fn perform_episode_variable_replacement(
+    retrieved_settings: Setting,
+    podcast_episode: PodcastEpisode,
+    podcast_settings: Option<PodcastSetting>,
+    episode_number: i64,
+) -> Result<String, CustomError> {
+```
+After `let total_time = podcast_episode.total_time.to_string();` add:
+```rust
+    let episode_number_str = episode_number.to_string();
+```
+After the `vars.insert("episodeDuration".to_string(), &total_time);` line add:
+```rust
+    vars.insert("episodeNumber".to_string(), &episode_number_str);
+```
+(No alias mapping is needed — users write `{episodeNumber}` directly, and `strfmt` format specs like `{episodeNumber:0>3}` pass through the existing `.replace(...)` chain unchanged.)
+
+- [ ] **Step 3: Update the production call site** in `prepare_podcast_episode_title_to_directory` (same file, ~line 333)
+
+Replace the body that parses the podcast id + calls the replacement with:
+```rust
+    let podcast_uuid = uuid::Uuid::parse_str(&podcast_episode.podcast_id)
+        .map_err(|_| CustomError::from(CustomErrorInner::NotFound(ErrorSeverity::Warning)))?;
+    let podcast_settings = PodcastSettingsService::get_settings_for_podcast(podcast_uuid)?;
+    let episode_number = crate::usecases::podcast_episode::PodcastEpisodeUseCase::get_position_of_episode(
+        &podcast_episode.date_of_recording,
+        podcast_uuid,
+    )? as i64;
+    perform_episode_variable_replacement(
+        retrieved_settings.into(),
+        podcast_episode,
+        podcast_settings,
+        episode_number,
+    )
+```
+
+- [ ] **Step 4: Update the remaining call sites** (preview/sample → position `1`)
+
+In `crates/podfetch-web/src/controllers/podcast_episode_controller.rs:558`, change:
+```rust
+    let result = perform_episode_variable_replacement(settings.into(), episode, None)?;
+```
+to:
+```rust
+    let result = perform_episode_variable_replacement(settings.into(), episode, None, 1)?;
+```
+In `crates/podfetch-web/src/services/settings/service.rs:89`, change:
+```rust
+        perform_episode_variable_replacement(transient_setting, sample_episode, None)?;
+```
+to:
+```rust
+        perform_episode_variable_replacement(transient_setting, sample_episode, None, 1)?;
+```
+In `crates/podfetch-web/src/services/file/service.rs`, update the three test call sites (currently lines ~634, ~681, ~728) to pass a final `1` argument.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo test -p podfetch-web --features sqlite file::service`
+Expected: PASS (including the new `episode_format_supports_episode_number_token`).
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/file/service.rs crates/podfetch-web/src/controllers/podcast_episode_controller.rs crates/podfetch-web/src/services/settings/service.rs
+git commit -m "feat(download-options): add {episodeNumber} filename token (#315)"
+```
+
+---
+
+## Task 7: Shared numbering helper + MP4 numbering fix
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/download/service.rs`
+
+- [ ] **Step 1: Write a failing test** in the `#[cfg(test)] mod` of `download/service.rs`
+
+```rust
+    #[test]
+    fn resolve_episode_title_handles_all_numbering_states() {
+        // numbering on, not yet processed → prefix + mark processed
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", false, true, 5),
+            Some(("5 - Ep".to_string(), true))
+        );
+        // numbering on, already processed → leave as-is
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", true, true, 5),
+            None
+        );
+        // numbering off → plain title, mark not-processed
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", false, false, 5),
+            Some(("Ep".to_string(), false))
+        );
+        assert_eq!(
+            super::DownloadService::resolve_episode_title("Ep", true, false, 5),
+            Some(("Ep".to_string(), false))
+        );
+    }
+```
+
+- [ ] **Step 2: Add the pure helper** as an associated fn on `DownloadService` (in `impl DownloadService`)
+
+```rust
+    /// Decide the title to embed and whether to (re)write the
+    /// `episode_numbering_processed` flag. Returns `None` when numbering is on
+    /// and the episode was already processed (leave the existing title alone).
+    pub(crate) fn resolve_episode_title(
+        name: &str,
+        episode_numbering_processed: bool,
+        numbering_enabled: bool,
+        index: usize,
+    ) -> Option<(String, bool)> {
+        if numbering_enabled {
+            if episode_numbering_processed {
+                None
+            } else {
+                Some((format!("{index} - {name}"), true))
+            }
+        } else {
+            Some((name.to_string(), false))
+        }
+    }
+```
+
+- [ ] **Step 3: Refactor `update_meta_data_mp3` to use the helper**
+
+Replace the numbering block (currently lines ~482-507, from `let settings_for_podcast =` through the trailing `else { ... }`) with:
+```rust
+        let settings_for_podcast =
+            PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
+        let numbering_enabled = settings_for_podcast
+            .as_ref()
+            .map(|s| s.episode_numbering)
+            .unwrap_or(false);
+        if let Some((title, processed)) = Self::resolve_episode_title(
+            &podcast_episode.name,
+            podcast_episode.episode_numbering_processed,
+            numbering_enabled,
+            index,
+        ) {
+            tag.set_title(title);
+            PodcastEpisodeService::update_episode_numbering_processed(
+                processed,
+                &podcast_episode.episode_id,
+            )?;
+        }
+```
+(`index` is already computed just above via `get_position_of_episode`.)
+
+- [ ] **Step 4: Apply numbering in `update_meta_data_mp4` (the bug fix)**
+
+In `update_meta_data_mp4`, replace `tag.set_title(&podcast_episode.name);` with:
+```rust
+                let index = PodcastEpisodeService::get_position_of_episode(
+                    &podcast_episode.date_of_recording,
+                    parse_id(&podcast_episode.podcast_id)?,
+                )?;
+                let settings_for_podcast =
+                    PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
+                let numbering_enabled = settings_for_podcast
+                    .as_ref()
+                    .map(|s| s.episode_numbering)
+                    .unwrap_or(false);
+                if let Some((title, processed)) = Self::resolve_episode_title(
+                    &podcast_episode.name,
+                    podcast_episode.episode_numbering_processed,
+                    numbering_enabled,
+                    index,
+                ) {
+                    tag.set_title(&title);
+                    PodcastEpisodeService::update_episode_numbering_processed(
+                        processed,
+                        &podcast_episode.episode_id,
+                    )?;
+                }
+```
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo test -p podfetch-web --features sqlite resolve_episode_title_handles_all_numbering_states`
+Expected: PASS.
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/download/service.rs
+git commit -m "fix(download-options): apply episode numbering to mp4 via shared helper (#315)"
+```
+
+---
+
+## Task 8: Wire NFO into the download path
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/download/service.rs`
+
+- [ ] **Step 1: Add the NFO call** in `download_podcast_episode`
+
+Insert immediately **after** `final_episode_path` is computed (the `let final_episode_path = ...` block, ~line 339-349) and **before** `PodcastEpisodeService::update_local_paths(...)` (~line 351):
+```rust
+        // Jellyfin/Kodi NFO sidecar files (non-fatal). Uses the FINAL media
+        // path so the per-episode .nfo basename matches the audio file even
+        // after Opus transcoding.
+        crate::services::nfo::service::regenerate_for_episode(
+            podcast,
+            &podcast_episode,
+            &final_episode_path,
+        );
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS. (`podcast` is `&PodcastEntity`, `podcast_episode` is `PodcastEpisodeEntity`, matching `regenerate_for_episode`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/download/service.rs
+git commit -m "feat(nfo): generate NFO on episode download (#315)"
+```
+
+---
+
+## Task 9: Wire NFO + cover rename into the settings-reapply path
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/podcast_settings/service.rs`
+
+- [ ] **Step 1: Regenerate NFO per episode inside the reapply loop**
+
+In `update_settings`, inside the `for episode in available_episodes` loop, after the `match DownloadService::handle_metadata_insertion(...) { ... }` block and before the loop ends, add:
+```rust
+            if let Some(audio_path) = episode
+                .file_episode_path
+                .as_deref()
+                .filter(|p| !p.is_empty())
+            {
+                crate::services::nfo::service::regenerate_for_episode(&podcast, &episode, audio_path);
+            }
+```
+
+- [ ] **Step 2: Rename the cover once after the loop**
+
+After the `for episode in available_episodes { ... }` loop closes and before `Ok(updated_setting.into())`, add:
+```rust
+        crate::services::nfo::service::ensure_cover_filename(&podcast);
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS. (`podcast` and `episode` here are persistence entities, matching the NFO service.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/podcast_settings/service.rs
+git commit -m "feat(nfo): regenerate NFO + rename cover when podcast settings change (#315)"
+```
+
+---
+
+## Task 10: Backfill rescan option (`regenerateNfo`)
+
+**Files:**
+- Modify: `crates/podfetch-web/src/services/episode_rescan/service.rs`
+- Modify: `ui/schema.d.ts` (RescanOptions)
+- Modify: `mobile/schema.d.ts` (RescanOptions)
+
+- [ ] **Step 1: Add the option field + toggle**
+
+In `struct RescanOptions`, append after `pub refetch_sponsorblock: bool,`:
+```rust
+    /// (Re)write NFO files for the episode (and rename the cover) using the
+    /// current settings, without re-downloading audio.
+    pub regenerate_nfo: bool,
+```
+In `impl RescanOptions::any_enabled`, add to the boolean chain:
+```rust
+            || self.regenerate_nfo
+```
+
+- [ ] **Step 2: Act on the option inside the per-episode loop**
+
+Near the existing `if opts.refetch_sponsorblock { ... }` block (~line 347), add:
+```rust
+        if opts.regenerate_nfo {
+            crate::services::nfo::service::regenerate_for_episode(
+                &podcast,
+                episode,
+                &final_audio_path,
+            );
+            crate::services::nfo::service::ensure_cover_filename(&podcast);
+        }
+```
+> `episode`, `podcast`, and `final_audio_path` are the loop-local bindings already used by the cover-consolidation/sponsorblock blocks. If `episode` is a reference there, pass it as-is; if owned, pass `&episode`. Match the existing `refetch_sponsorblock` block's usage (it uses `&episode.clone()` / `episode` — mirror it).
+
+- [ ] **Step 3: Add the unit assertion** to the existing rescan test module
+
+In `rescan_options_any_enabled_reflects_individual_toggles`, add:
+```rust
+        assert!(
+            RescanOptions {
+                regenerate_nfo: true,
+                ..RescanOptions::default()
+            }
+            .any_enabled()
+        );
+```
+
+- [ ] **Step 4: Add `regenerateNfo` to `RescanOptions` in both schema files**
+
+In `ui/schema.d.ts`, inside the `RescanOptions` object (the block near line 1824 that documents `apply_covers`), add after the existing `refetchSponsorblock` property (matching the surrounding `@default false` doc style):
+```ts
+            /**
+             * @description (Re)write NFO files for the episode (and rename the cover)
+             *     using the current settings, without re-downloading audio.
+             * @default false
+             */
+            regenerateNfo?: boolean;
+```
+Apply the **same** addition to `mobile/schema.d.ts` in its `RescanOptions` block.
+
+- [ ] **Step 5: Build + test**
+
+Run: `cargo test -p podfetch-web --features sqlite rescan_options_any_enabled`
+Expected: PASS.
+Run: `cargo build -p podfetch-web --features sqlite`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/podfetch-web/src/services/episode_rescan/service.rs ui/schema.d.ts mobile/schema.d.ts
+git commit -m "feat(nfo): add regenerateNfo backfill rescan option (#315)"
+```
+
+---
+
+## Task 11: Frontend — expose `nfoFormat` + `coverFilename`
+
+Mirror the existing `useOneCoverForAllEpisodes` field everywhere it appears. Open each file and copy that field's wiring for the two new fields.
+
+**Files:**
+- Modify: `ui/schema.d.ts`
+- Modify: `mobile/schema.d.ts`
+- Modify: `ui/src/models/Setting.tsx`
+- Modify: `ui/src/models/PodcastSetting.ts`
+- Modify: `ui/src/models/PodcastDefaultSettings.tsx`
+- Modify: `ui/src/components/SettingsNaming.tsx`
+- Modify: `ui/src/components/PodcastSettingsModal.tsx`
+
+- [ ] **Step 1: Add types to `ui/schema.d.ts`**
+
+In the `Setting` schema object (the block where `useOneCoverForAllEpisodes: boolean;` appears, ~line 1798), add after it:
+```ts
+            nfoFormat: string;
+            coverFilename: string;
+```
+Do the same in the per-podcast settings schema object (the second `useOneCoverForAllEpisodes` occurrence, ~line 1871).
+
+- [ ] **Step 2: Add the same two lines to `mobile/schema.d.ts`**
+
+Run: `rg -n "useOneCoverForAllEpisodes" mobile/schema.d.ts`
+For each occurrence inside a settings object, add `nfoFormat: string;` and `coverFilename: string;` after it (same as Step 1).
+
+- [ ] **Step 3: Update the TS models**
+
+In `ui/src/models/Setting.tsx`, `ui/src/models/PodcastSetting.ts`, and `ui/src/models/PodcastDefaultSettings.tsx`: locate the `useOneCoverForAllEpisodes` field (type + any default/initializer) and add `nfoFormat` (string, default `"off"`) and `coverFilename` (string, default `"image"`) right beside it, following the exact shape of that field in each file.
+
+- [ ] **Step 4: Add the form controls**
+
+In `ui/src/components/SettingsNaming.tsx` (global) and `ui/src/components/PodcastSettingsModal.tsx` (per-podcast): near the `useOneCoverForAllEpisodes` control, add:
+- A `<select>` bound to `nfoFormat` with options `off` / `tvshow` / `album` (labels e.g. "No NFO files" / "Jellyfin TV-show" / "Music album").
+- A text `<input>` bound to `coverFilename` (placeholder `image`).
+
+Wire both into the same change/submit handler the existing fields use (copy how `useOneCoverForAllEpisodes` is read and written in the component's state + payload).
+
+- [ ] **Step 5: Type-check + build the frontend**
+
+Run: `cd ui && npm run build`
+Expected: PASS (tsc + vite). Fix any type errors surfaced by the new fields.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/schema.d.ts mobile/schema.d.ts ui/src/models/Setting.tsx ui/src/models/PodcastSetting.ts ui/src/models/PodcastDefaultSettings.tsx ui/src/components/SettingsNaming.tsx ui/src/components/PodcastSettingsModal.tsx
+git commit -m "feat(download-options): NFO format + cover filename UI (#315)"
+```
+
+---
+
+## Task 12: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Clippy on all three feature configurations**
+
+Run: `cargo clippy --all-targets --features sqlite -- -D warnings`
+Run: `cargo clippy --all-targets --features postgresql -- -D warnings`
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: no warnings on any. (Do NOT run `cargo fmt`.)
+
+- [ ] **Step 2: Tests (sqlite locally; postgres runs in CI)**
+
+Run: `cargo test --features sqlite`
+Expected: PASS. (Postgres-backed tests run in the CI `Build postgres` job — they need a testcontainer DB not assumed locally.)
+
+- [ ] **Step 3: Frontend**
+
+Run: `cd ui && npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Final commit (only if Step 1-3 required fixes)**
+
+```bash
+git add -A
+git commit -m "chore(download-options): clippy/test fixes for NFO feature (#315)"
+```
+
+- [ ] **Step 5: Push + open PR** (per finishing-a-development-branch, option 2)
+
+```bash
+git push -u origin feat/download-options-315
+gh pr create --title "feat: NFO files, {episodeNumber} token & Jellyfin polish (#315)" --body "$(cat <<'EOF'
+## Summary
+- Configurable Jellyfin/Kodi NFO generation (`nfo_format` = off | tvshow | album), global + per-podcast.
+- `{episodeNumber}` filename token (1-based date position; zero-pad via `{episodeNumber:0>3}`).
+- Fix episode numbering for `.m4a`/`.mp4` (shared `resolve_episode_title` helper).
+- Configurable podcast cover filename (`cover_filename`, default `image`); renamed on change.
+- NFO written on download, regenerated on podcast settings change, and backfillable via the `regenerateNfo` rescan option.
+
+Closes #315.
+
+## Test Plan
+- [ ] `cargo clippy --all-targets --features sqlite -- -D warnings` (and `--features postgresql`, and default)
+- [ ] `cargo test --features sqlite`
+- [ ] `cd ui && npm run build`
+- [ ] Manual: set a podcast to `tvshow`, download an episode, confirm `tvshow.nfo` + `<episode>.nfo`; set to `album`, confirm `album.nfo`; set `cover_filename=cover`, run rescan with `regenerateNfo`, confirm `image.jpg`→`cover.jpg`.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 data model (nfo_format, cover_filename, both tables, resolution rule, sqlite+postgres) → Task 1. ✓
+- §3 NFO module (NfoFormat, builders, quick_xml, field mapping) → Tasks 2-3. ✓
+- §3 dispatch/writer + non-fatal → Task 4. ✓
+- §4 wiring: download → Task 8; reapply → Task 9; backfill rescan → Task 10. ✓
+- §4 cover filename: new downloads → Task 5; rename-on-change → Task 4 (`ensure_cover_filename`) + Tasks 9/10. ✓
+- §5 `{episodeNumber}` token → Task 6; MP4 numbering fix via shared helper → Task 7. ✓
+- §6 tests: builders golden/structural (Task 3), `NfoFormat::from_str` (Task 2), `{episodeNumber}` (Task 6), `resolve_episode_title` (Task 7), `.nfo` path (Task 4), settings round-trip (Task 1); DTO serde defaults (Task 1, `#[serde(default)]`). ✓
+- §6 verification gate → Task 12. ✓
+- Frontend exposure (implied by "global + per-podcast" + schema.d.ts convention) → Task 11. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows complete code or an exact transformation anchored to a named existing field/line. Frontend Task 11 references the concrete existing `useOneCoverForAllEpisodes` field as the copy template (not vague).
+
+**Type consistency:** `resolve_nfo_format`/`resolve_cover_filename`/`regenerate_for_episode`/`ensure_cover_filename`/`nfo_path_for` (Task 4) are used with matching signatures in Tasks 5/8/9/10. `resolve_episode_title(name, processed, numbering_enabled, index)` defined and called identically in Task 7 (mp3 + mp4) and tested in Task 7. `perform_episode_variable_replacement(..., episode_number: i64)` defined in Task 6 and all call sites updated in the same task. Builders take domain `Podcast`/`PodcastEpisode`; call sites convert from entities via existing `From` impls.

--- a/docs/superpowers/specs/2026-06-06-download-options-nfo-design.md
+++ b/docs/superpowers/specs/2026-06-06-download-options-nfo-design.md
@@ -1,0 +1,250 @@
+# Download Options: NFO Files, Numbering Token & Jellyfin Polish — Design
+
+**Issue:** [#315 — More download options (folder structure, images, .nfo files etc)](https://github.com/SamTV12345/PodFetch/issues/315)
+**Date:** 2026-06-06
+**Status:** Approved (ready for implementation plan)
+
+## 1. Background & problem
+
+Issue #315 (open since 2023, last comment 2025-06) is a cluster of requests around how
+downloaded podcast files are organized on disk, framed mostly around Jellyfin
+compatibility. An audit of the current code shows **most of the original request is
+already shipped**:
+
+- **Configurable naming templates** — `episode_format` / `podcast_format` with tokens
+  `{title}`, `{date}`, `{guid}`, `{url}`, `{description}`, `{duration}` (global +
+  per-podcast override), via the `strfmt` crate.
+- **Flat Jellyfin-style layout** — `direct_paths = true` produces
+  `Podcast/Episode Title.mp3` with the episode image written as
+  `Podcast/Episode Title.jpg` beside it (`podfetch-storage/src/filename.rs:67`).
+- **pubdate ordering** — users can already use `{date} - {title}`.
+- **Skip duplicate episode images** — `use_one_cover_for_all_episodes = true` skips
+  downloading/writing per-episode images entirely (added 2026-05, after the duplicate-cover
+  complaint).
+- **Sanitization** of illegal filename characters via `replacement_strategy`.
+
+The **genuine remaining gaps** this design addresses:
+
+1. **`.nfo` metadata files** — nothing exists today (only embedded ID3/MP4 tags). This is
+   the headline ask and the one item never addressed.
+2. **Episode numbering as a filename token** — today `episode_numbering` only prepends the
+   number to the embedded *title tag*; it never changes the filename, which is why it
+   "does nothing" in a file browser / Jellyfin folder view. It is also applied for MP3 only;
+   the MP4 writer skips it.
+3. **Jellyfin cover filename** — the cover is hardcoded to `image.<ext>`; Jellyfin's scanner
+   auto-detects art only from `cover.*` / `folder.*` / `poster.*`.
+
+### Approved scope
+
+Full scope: NFO generation (configurable per podcast), the `{episodeNumber}` filename token,
+the MP4 numbering fix, and a configurable cover filename. Backfill of existing libraries
+included.
+
+### Key decisions (from brainstorming)
+
+- **NFO format:** configurable — `nfo_format = "off" | "tvshow" | "album"` (global + per-podcast
+  override). Both writers are built.
+- **Generation/sync:** on each download + regenerate on podcast settings change + a backfill
+  rescan for already-downloaded episodes (no audio re-download).
+- **Cover filename:** configurable, default `image` (existing libraries untouched); backfill
+  renames on change. Not auto-derived, not a forced migration.
+- **Integration:** dedicated `nfo` service module with pure builders + a thin, non-fatal writer
+  (Approach A), invoked at the download / reapply / backfill sites.
+
+## 2. Data model / settings
+
+Two new columns, added to **both** `settings` (global) and `podcast_settings` (per-podcast),
+following the `use_one_cover_for_all_episodes` / `replacement_strategy` precedent:
+
+| Column | Type | Default | Meaning |
+|---|---|---|---|
+| `nfo_format` | `TEXT NOT NULL` | `'off'` | `'off'` \| `'tvshow'` \| `'album'`. Parsed into `NfoFormat` via `FromStr`. Default `off` ⇒ opt-in; no change for existing users. |
+| `cover_filename` | `TEXT NOT NULL` | `'image'` | Base name of the podcast cover file. Default `image` ⇒ existing libraries untouched. |
+
+**Resolution rule** (unchanged pattern): if a `podcast_settings` row exists *and*
+`activated = true`, use its values; otherwise fall back to global `settings`
+(`.map(...).unwrap_or(global)`, as at `download/service.rs:210`).
+
+**Migrations** target **sqlite + postgres only** (MySQL is not a maintained backend — 3
+migrations vs 48 sqlite / 33 postgres; neither SponsorBlock nor `use_one_cover` was added
+there). Two `ALTER TABLE ... ADD COLUMN` per backend, in
+`migrations/{sqlite,postgres}/<ts>_nfo_options/{up,down}.sql`.
+
+**Propagation touch-list** (standard for a new setting, identical to SponsorBlock T3):
+`schema.rs` `table!` blocks (both tables) → domain `Setting` + `PodcastSetting` (+ `NfoFormat`
+enum) → persistence entities/repos → web DTOs (`settings.rs`, `podcast_settings.rs`, with
+`#[serde(default)]`) → UI settings + per-podcast forms → `ui/schema.d.ts` + `mobile/schema.d.ts`
+(hand-edited).
+
+## 3. NFO module
+
+`crates/podfetch-web/src/services/nfo/`:
+
+- `mod.rs` — `NfoFormat` enum (`Off`/`Tvshow`/`Album`) + `FromStr`; format dispatch.
+- `builders.rs` — **pure** functions returning XML strings via `quick_xml::Writer` (indented).
+  No DB, no FS ⇒ golden-XML unit tests. `quick_xml` is already a dependency (the audiobookshelf
+  importer parses NFO with it).
+- `service.rs` — resolves format from settings, computes paths, writes files; **non-fatal**
+  (warn + continue, exactly like the SponsorBlock hook at `download/service.rs:327`).
+
+### Available metadata
+
+- **Podcast:** `name`, `summary`, `language`, `explicit`, `keywords`, `author`, `guid`,
+  `last_build_date`.
+- **Episode:** `name`, `description`, `date_of_recording` (string), `total_time` (seconds),
+  `guid`, `url`.
+- "Persons" maps to the podcast-level `author` (no per-episode person list / `podcast:person`
+  parsing exists). No `itunes:episode` / `itunes:season` is parsed, so episode/track numbers
+  come from the computed date-position only; there is no season concept.
+
+### Builders / output
+
+`build_tvshow_nfo(&Podcast)` → **`tvshow.nfo`** at the podcast root:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<tvshow>
+  <title>{podcast.name}</title>
+  <plot>{podcast.summary}</plot>          <!-- omitted if None -->
+  <studio>{podcast.author}</studio>       <!-- omitted if None -->
+  <genre>{podcast.keywords}</genre>       <!-- omitted if None -->
+  <uniqueid type="podfetch">{podcast.guid}</uniqueid>
+</tvshow>
+```
+
+`build_episodedetails_nfo(&Podcast, &PodcastEpisode, position)` → per-episode
+**`<audio-basename>.nfo`** (extension swapped from the resolved audio path ⇒ correct in both
+flat and nested layouts):
+
+```xml
+<episodedetails>
+  <title>{episode.name}</title>
+  <showtitle>{podcast.name}</showtitle>
+  <season>1</season>                            <!-- no season data; constant 1 -->
+  <episode>{position}</episode>                 <!-- get_position_of_episode -->
+  <plot>{episode.description}</plot>
+  <aired>{YYYY-MM-DD from date_of_recording}</aired>
+  <runtime>{total_time/60, rounded}</runtime>   <!-- Kodi runtime = minutes -->
+  <actor><name>{podcast.author}</name></actor>  <!-- "persons"; omitted if None -->
+  <uniqueid type="podfetch">{episode.guid}</uniqueid>
+</episodedetails>
+```
+
+`build_album_nfo(&Podcast, &[(PodcastEpisode, position)])` → single **`album.nfo`** at the
+root (no per-episode files); rewritten whenever an episode is added:
+
+```xml
+<album>
+  <title>{podcast.name}</title>
+  <artist>{podcast.author}</artist>       <!-- omitted if None -->
+  <genre>{podcast.keywords}</genre>
+  <review>{podcast.summary}</review>
+  <track><position>{n}</position><title>{episode.name}</title><duration>{total_time}</duration></track>
+  <!-- one per downloaded episode, ordered by date -->
+</album>
+```
+
+### Notes
+
+- **Escaping** handled by `quick_xml` (`BytesText` auto-escapes `& < > " '`); descriptions with
+  `&`/HTML are safe. Descriptions are written as-is (escaped); HTML-stripping is out of scope.
+- **Dispatch:** `off` → nothing; `tvshow` → per-episode `.nfo` + refresh `tvshow.nfo`;
+  `album` → rewrite `album.nfo` from the full downloaded set (no per-episode files).
+- `position` reuses `get_position_of_episode`; album `<position>`/ordering reuses
+  `get_track_number_for_episode`.
+
+## 4. Wiring & backfill
+
+Three invocation sites — all best-effort / non-fatal (warn-and-continue, never break a
+download or settings save):
+
+1. **Download path** — in `download_podcast_episode`, after audio + image are written and after
+   `handle_metadata_insertion`. Resolve `nfo_format` (per-podcast → global), then:
+   - `tvshow` → write this episode's `<basename>.nfo` (position via `get_position_of_episode`)
+     and overwrite `tvshow.nfo` (idempotent).
+   - `album` → rewrite `album.nfo` from the podcast's full downloaded episode set.
+   - Per-episode `.nfo` path = the resolved audio path with its extension swapped to `.nfo`
+     (works in both layouts).
+2. **Settings-change reapply path** — `podcast_settings/service.rs:64-95` already re-applies
+   metadata to every downloaded episode when per-podcast settings change. Hook NFO regeneration
+   + cover-rename here so flipping `nfo_format` / `cover_filename` updates the existing library.
+3. **Backfill rescan option** — add `regenerate_nfo` to `episode_rescan` (which already carries
+   `refetch_sponsorblock` and `apply_covers`). Per podcast, (re)write all NFO files and rename
+   the cover if needed, **without re-downloading audio**. This is the "organize my existing
+   collection" path.
+
+**Cover-filename wiring:**
+
+- Thread the resolved `cover_filename` into `build_podcast_image_paths`
+  (`podfetch-storage/src/path.rs`), replacing the hardcoded `image`, so new downloads write
+  `{dir}/{cover_filename}.{ext}`.
+- **Rename-on-change:** when the resolved cover name differs from what's on disk (reapply or
+  backfill), rename `{dir}/{old}.{ext}` → `{dir}/{cover_filename}.{ext}` and update the stored
+  image path via the existing `update_*image*` repo methods. The old name is found from the
+  podcast's recorded cover path.
+
+**Concurrency:** `album.nfo` is rebuilt from the committed downloaded set on each write, so
+concurrent same-podcast downloads are eventually consistent (last writer includes all-so-far;
+the reapply/backfill path fully reconciles). `tvshow.nfo` writes are idempotent overwrites.
+
+## 5. Numbering token, MP4 fix, cover setting
+
+**`{episodeNumber}` filename token** (the real fix for "numbering does nothing"):
+
+- Added to `perform_episode_variable_replacement` (`file/service.rs:340`). Value = the episode's
+  **1-based position** = `get_position_of_episode(date, podcast_id)`, so the filename number and
+  the embedded title number agree.
+- That function is intentionally DB-free, so `episode_number` is **threaded in as a parameter**
+  (computed by the caller — a query already done nearby in the download path). The signature
+  change ripples to its callers (download + reapply/rescan), each of which has `podcast_id`.
+- Inserted into `vars` as `episodeNumber`; users write `{episodeNumber}` in `episode_format`.
+  **Zero-padding works via `strfmt` specs** — `{episodeNumber:0>3}` → `007` (survives the
+  existing comma-strip/trim). No second token (YAGNI).
+- **Independent** of the per-podcast `episode_numbering` bool: the token numbers *filenames*
+  (works globally via `episode_format`); `episode_numbering` numbers the *embedded title tag*.
+  Keeping them separate is deliberate.
+
+**MP4 numbering fix** (`update_meta_data_mp4:558`): currently always `set_title(name)`. Extract
+the title decision shared by both writers — `resolve_episode_title(episode, podcast, index)
+-> (String, bool /*processed*/)` — and call it from both `update_meta_data_mp3` and
+`update_meta_data_mp4`, so M4A episodes get numbered titles identically and the paths can't drift.
+
+**Scope guard:** no global `episode_numbering` bool is added. The per-podcast title-tag toggle
+stays (now MP4-correct); the global filename-numbering need is served by `{episodeNumber}` in
+the global `episode_format`.
+
+**Edge case:** episodes sharing an identical `date_of_recording` get the same position (a tie) —
+the same behavior the existing numbering already has; acceptable.
+
+## 6. Testing
+
+Most logic is pure ⇒ covered without DB or FS:
+
+| Test | Kind | Covers |
+|---|---|---|
+| NFO builder golden-XML | pure unit (`builders.rs`) | exact `tvshow`/`episodedetails`/`album` output; `None`-field omission; escaping (`&`, `<`); runtime sec→min; album multi-track ordering |
+| `NfoFormat::from_str` | pure unit | `off`/`tvshow`/`album` + unknown → default |
+| `perform_episode_variable_replacement` w/ `{episodeNumber}` | pure unit | plain + `{episodeNumber:0>3}` |
+| `resolve_episode_title` | pure unit | enabled / disabled / no-settings / already-processed → title + `processed` |
+| `.nfo` path derivation | pure unit | flat → `{stem}.nfo`, nested → `audio.nfo` |
+| settings + podcast_settings round-trip | persistence (`--features sqlite`) | new columns default + update persists; uses crate-wide `db::test_db::setup()` lock |
+| settings DTO serde | web unit | new fields (de)serialize with `#[serde(default)]` |
+
+**Explicit non-goals (no silent gaps):**
+
+- No full network download→file-on-disk integration test (heavy, live audio). Download path is
+  covered via the unit-tested builder + the non-fatal call-site pattern (as with SponsorBlock).
+- MP4 tag *writing* isn't unit-tested (needs an `.m4a` fixture); the **numbering decision** is,
+  via `resolve_episode_title`.
+
+**Verification gate** (final plan task, as SponsorBlock T12): `clippy -D warnings` on default /
+`--features sqlite` / `--features postgresql`; tests on sqlite + postgres; frontend `tsc` +
+build; `schema.d.ts` consistency. **No `cargo fmt`** (repo convention).
+
+## 7. Out of scope
+
+- HTML-stripping of descriptions inside NFO `<plot>`/`<review>` (written escaped; a later nicety).
+- Global `episode_numbering` toggle (served by the `{episodeNumber}` template token).
+- MySQL migrations (not a maintained backend).
+- Per-episode person/host lists / `podcast:person` parsing (only podcast-level `author` exists).
+- A full network download integration test.

--- a/migrations/postgres/2026-06-06-130000_nfo_options/down.sql
+++ b/migrations/postgres/2026-06-06-130000_nfo_options/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE settings DROP COLUMN nfo_format;
+ALTER TABLE settings DROP COLUMN cover_filename;
+ALTER TABLE podcast_settings DROP COLUMN nfo_format;
+ALTER TABLE podcast_settings DROP COLUMN cover_filename;

--- a/migrations/postgres/2026-06-06-130000_nfo_options/up.sql
+++ b/migrations/postgres/2026-06-06-130000_nfo_options/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';
+ALTER TABLE podcast_settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE podcast_settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';

--- a/migrations/sqlite/2026-06-06-130000_nfo_options/down.sql
+++ b/migrations/sqlite/2026-06-06-130000_nfo_options/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE settings DROP COLUMN nfo_format;
+ALTER TABLE settings DROP COLUMN cover_filename;
+ALTER TABLE podcast_settings DROP COLUMN nfo_format;
+ALTER TABLE podcast_settings DROP COLUMN cover_filename;

--- a/migrations/sqlite/2026-06-06-130000_nfo_options/up.sql
+++ b/migrations/sqlite/2026-06-06-130000_nfo_options/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';
+ALTER TABLE podcast_settings ADD COLUMN nfo_format TEXT NOT NULL DEFAULT 'off';
+ALTER TABLE podcast_settings ADD COLUMN cover_filename TEXT NOT NULL DEFAULT 'image';

--- a/mobile/schema.d.ts
+++ b/mobile/schema.d.ts
@@ -1700,6 +1700,19 @@ export interface components {
              * @default false
              */
             applyTranscode: boolean;
+            /**
+             * @description Re-query SponsorBlock and replace stored segments for the episode.
+             *     For episodes ingested before SponsorBlock support, the YouTube video id
+             *     is backfilled in-memory from the guid/url for this fetch.
+             * @default false
+             */
+            refetchSponsorblock?: boolean;
+            /**
+             * @description (Re)write NFO files for the episode (and rename the cover)
+             *     using the current settings, without re-downloading audio.
+             * @default false
+             */
+            regenerateNfo?: boolean;
         };
         Setting: {
             autoCleanup: boolean;

--- a/mobile/schema.d.ts
+++ b/mobile/schema.d.ts
@@ -1650,6 +1650,8 @@ export interface components {
             replacementStrategy: string;
             useExistingFilename: boolean;
             useOneCoverForAllEpisodes: boolean;
+            nfoFormat: string;
+            coverFilename: string;
         };
         PodcastUpdateNameRequest: {
             name: string;
@@ -1733,6 +1735,8 @@ export interface components {
             replacementStrategy: string;
             useExistingFilename: boolean;
             useOneCoverForAllEpisodes: boolean;
+            nfoFormat: string;
+            coverFilename: string;
         };
         SimplifiedDisk: {
             /** Format: int64 */

--- a/ui/schema.d.ts
+++ b/ui/schema.d.ts
@@ -1846,6 +1846,19 @@ export interface components {
              * @default false
              */
             applyTranscode: boolean;
+            /**
+             * @description Re-query SponsorBlock and replace stored segments for the episode.
+             *     For episodes ingested before SponsorBlock support, the YouTube video id
+             *     is backfilled in-memory from the guid/url for this fetch.
+             * @default false
+             */
+            refetchSponsorblock?: boolean;
+            /**
+             * @description (Re)write NFO files for the episode (and rename the cover)
+             *     using the current settings, without re-downloading audio.
+             * @default false
+             */
+            regenerateNfo?: boolean;
         };
         Setting: {
             autoCleanup: boolean;

--- a/ui/schema.d.ts
+++ b/ui/schema.d.ts
@@ -1796,6 +1796,8 @@ export interface components {
             replacementStrategy: string;
             useExistingFilename: boolean;
             useOneCoverForAllEpisodes: boolean;
+            nfoFormat: string;
+            coverFilename: string;
         };
         PodcastUpdateNameRequest: {
             name: string;
@@ -1882,6 +1884,8 @@ export interface components {
             replacementStrategy: string;
             useExistingFilename: boolean;
             useOneCoverForAllEpisodes: boolean;
+            nfoFormat: string;
+            coverFilename: string;
         };
         SimplifiedDisk: {
             /** Format: int64 */

--- a/ui/src/components/PodcastSettingsModal.tsx
+++ b/ui/src/components/PodcastSettingsModal.tsx
@@ -251,6 +251,28 @@ export const PodcastSettingsModal: FC<PodcastSettingsModalProps> = ({
                             />
 
                             <label className="col-span-2 ui-text">
+                                {t('nfo-format')}
+                            </label>
+                            <CustomSelect
+                                value={draft.nfoFormat}
+                                options={[
+                                    { label: 'No NFO files', value: 'off' },
+                                    { label: 'Jellyfin TV-show', value: 'tvshow' },
+                                    { label: 'Music album', value: 'album' },
+                                ]}
+                                onChange={(v) => update('nfoFormat', v)}
+                            />
+
+                            <label className="col-span-2 ui-text">
+                                {t('cover-filename')}
+                            </label>
+                            <CustomInput
+                                placeholder="image"
+                                value={draft.coverFilename}
+                                onChange={(e) => update('coverFilename', e.target.value)}
+                            />
+
+                            <label className="col-span-2 ui-text">
                                 {t('number-of-podcasts-to-download')}
                                 <SettingsInfoIcon
                                     headerKey="number-of-podcasts-to-download"

--- a/ui/src/components/SettingsData.tsx
+++ b/ui/src/components/SettingsData.tsx
@@ -4,6 +4,7 @@ import { Setting } from '../models/Setting'
 import { CustomButtonPrimary } from './CustomButtonPrimary'
 import { CustomButtonSecondary } from './CustomButtonSecondary'
 import { CustomInput } from './CustomInput'
+import { CustomSelect } from './CustomSelect'
 import { Switcher } from './Switcher'
 import { SettingsInfoIcon } from './SettingsInfoIcon'
 import {$api} from '../utils/http'
@@ -101,6 +102,33 @@ export const Settings = () => {
                             useOneCoverForAllEpisodes: !oldData?.useOneCoverForAllEpisodes
                         }))
                     }} />
+                </div>
+                <div className="flex flex-col gap-2 xs:contents mb-4">
+                    <label htmlFor="nfo-format" className="flex gap-1">{t('nfo-format')}</label>
+                    <CustomSelect
+                        id="nfo-format"
+                        value={settingsModel.data?.nfoFormat ?? 'off'}
+                        options={[
+                            { label: 'No NFO files', value: 'off' },
+                            { label: 'Jellyfin TV-show', value: 'tvshow' },
+                            { label: 'Music album', value: 'album' },
+                        ]}
+                        onChange={(v) => {
+                            queryClient.setQueryData(['get', '/api/v1/settings'], (oldData: Setting) => ({
+                                ...oldData,
+                                nfoFormat: v
+                            }))
+                        }}
+                    />
+                </div>
+                <div className="flex flex-col gap-2 xs:contents mb-4">
+                    <label htmlFor="cover-filename" className="flex gap-1">{t('cover-filename')}</label>
+                    <CustomInput loading={settingsModel.isLoading} id="cover-filename" placeholder="image" onChange={(e) => {
+                        queryClient.setQueryData(['get', '/api/v1/settings'], (oldData: Setting) => ({
+                            ...oldData,
+                            coverFilename: e.target.value
+                        }))
+                    }} value={settingsModel.data?.coverFilename ?? 'image'} />
                 </div>
             </div>
 

--- a/ui/src/components/SettingsRescan.tsx
+++ b/ui/src/components/SettingsRescan.tsx
@@ -25,6 +25,8 @@ export const SettingsRescan: FC = () => {
         applyTranscode: false,
         applyCovers: false,
         applyMetadata: false,
+        refetchSponsorblock: false,
+        regenerateNfo: false,
     })
 
     const setOption = (key: typeof OPTION_KEYS[number], value: boolean) => {

--- a/ui/src/models/PodcastDefaultSettings.tsx
+++ b/ui/src/models/PodcastDefaultSettings.tsx
@@ -16,6 +16,8 @@ export const generatePodcastDefaultSettings = (podcastId: string) => {
         replaceInvalidCharacters: false,
         replacementStrategy: "replace-with-dash-and-underscore",
         useExistingFilename: false,
-        useOneCoverForAllEpisodes: false
+        useOneCoverForAllEpisodes: false,
+        nfoFormat: "off",
+        coverFilename: "image"
     } satisfies components['schemas']['PodcastSetting']
 }

--- a/ui/src/models/PodcastSetting.ts
+++ b/ui/src/models/PodcastSetting.ts
@@ -14,4 +14,6 @@ export type PodcastSetting = {
     activated: boolean,
     podcastPrefill: number,
     useOneCoverForAllEpisodes: boolean,
+    nfoFormat: string,
+    coverFilename: string,
 }

--- a/ui/src/models/Setting.tsx
+++ b/ui/src/models/Setting.tsx
@@ -13,5 +13,7 @@ export type Setting = {
     directPaths: boolean,
     autoTranscodeOpus: boolean,
     useOneCoverForAllEpisodes: boolean,
+    nfoFormat: string,
+    coverFilename: string,
     maxParallelDownloads: number,
 }


### PR DESCRIPTION
## Summary

Implements the long-standing requests in #315 around download-file organisation, focused on the genuine gaps (most of #315 — naming templates, flat `direct_paths` layout, `{date}` ordering, single-cover reuse — already shipped).

- **Configurable Jellyfin/Kodi NFO generation** — new `nfo_format` setting (`off` | `tvshow` | `album`), global with per-podcast override.
  - `tvshow` → `tvshow.nfo` at the podcast root + one `<episodedetails>` `.nfo` per episode (named to match the media file).
  - `album` → a single `album.nfo` listing every downloaded episode as a `<track>`.
  - Pure XML builders (`quick_xml`) with golden/structural tests; all file writes are **non-fatal** (logged, never break a download or a settings save).
- **`{episodeNumber}` filename token** — usable in `episode_format`; 1-based episode position, agrees with the embedded numbering. Zero-pad via `strfmt` specs, e.g. `{episodeNumber:0>3}` → `007`. This is the real fix for the "numbering does nothing" report (the old per-podcast toggle only changed the embedded *title tag*, never the filename).
- **`.m4a`/`.mp4` numbering fix** — episode numbering was MP3-only; extracted a shared `resolve_episode_title` helper now used by both the MP3 and MP4 tag writers.
- **Configurable cover filename** — new `cover_filename` setting (default `image`, so existing libraries are untouched); set `cover`/`folder`/`poster` for Jellyfin auto-detection. New downloads honour it; existing covers are renamed by the reapply/backfill paths.
- **Generation & backfill** — NFO is written on download, regenerated when podcast settings change, and backfillable over an existing library via a new `regenerateNfo` rescan option (no audio re-download).
- **UI** — global + per-podcast controls for NFO format and cover filename.

Migrations target sqlite + postgres. Default `off`/`image` make the whole feature opt-in.

Closes #315.

## Test Plan

- [x] `cargo clippy --no-default-features --features sqlite --all-targets -- -D warnings`
- [x] `cargo clippy --no-default-features --features postgresql --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (default features)
- [x] `cargo test --no-default-features --workspace --features sqlite`
- [x] Frontend: `pnpm run tsc:check`, `pnpm run test`, `pnpm run build`
- [ ] Postgres / all-features test suites — covered by CI (need a testcontainers DB)
- [ ] Manual: set a podcast to `tvshow`, download an episode → confirm `tvshow.nfo` + `<episode>.nfo`; switch to `album` → confirm `album.nfo`; set `cover_filename=cover` and run a rescan with `regenerateNfo` → confirm `image.jpg` is renamed to `cover.jpg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)