### PR TITLE
chore: fixed errors in lockfile by changing order of exectutions

### DIFF
--- a/crates/common-infrastructure/src/db.rs
+++ b/crates/common-infrastructure/src/db.rs
@@ -81,14 +81,14 @@ impl r2d2::CustomizeConnection<DBType, diesel::r2d2::Error> for ConnectionOption
     fn on_acquire(&self, conn: &mut DBType) -> Result<(), diesel::r2d2::Error> {
         use diesel::connection::SimpleConnection;
         (|| {
+            if let Some(d) = self.busy_timeout {
+                conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d.as_millis()))?;
+            }
             if self.enable_wal {
                 conn.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")?;
             }
             if self.enable_foreign_keys {
                 conn.batch_execute("PRAGMA foreign_keys = ON;")?;
-            }
-            if let Some(d) = self.busy_timeout {
-                conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d.as_millis()))?;
             }
             Ok(())
         })()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/SamTV12345/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The problem was that the wal file was first locked while the correct order is first setting busy timeout

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
