### PR TITLE
feat: add episode numbering option to general settings

### DIFF
--- a/crates/podfetch-domain/src/settings.rs
+++ b/crates/podfetch-domain/src/settings.rs
@@ -5,6 +5,10 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Setting {
     pub id: Uuid,
+    /// Instance-wide default for prefixing the embedded episode title with its
+    /// position (`{index} - {name}`). Acts as a fallback that is OR-ed with the
+    /// per-podcast `episode_numbering` flag, mirroring `auto_download`.
+    pub episode_numbering: bool,
     pub auto_download: bool,
     pub auto_update: bool,
     pub auto_cleanup: bool,

--- a/crates/podfetch-persistence/src/schema.rs
+++ b/crates/podfetch-persistence/src/schema.rs
@@ -220,6 +220,7 @@ diesel::table! {
 diesel::table! {
     settings (id) {
         id -> Text,
+        episode_numbering -> Bool,
         auto_download -> Bool,
         auto_update -> Bool,
         auto_cleanup -> Bool,

--- a/crates/podfetch-persistence/src/settings.rs
+++ b/crates/podfetch-persistence/src/settings.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 diesel::table! {
     settings (id) {
         id -> Text,
+        episode_numbering -> Bool,
         auto_download -> Bool,
         auto_update -> Bool,
         auto_cleanup -> Bool,
@@ -32,6 +33,7 @@ diesel::table! {
 #[diesel(table_name = settings)]
 struct SettingEntity {
     id: String,
+    episode_numbering: bool,
     auto_download: bool,
     auto_update: bool,
     auto_cleanup: bool,
@@ -55,6 +57,7 @@ impl From<SettingEntity> for Setting {
     fn from(value: SettingEntity) -> Self {
         Self {
             id: Uuid::parse_str(&value.id).expect("valid uuid in db"),
+            episode_numbering: value.episode_numbering,
             auto_download: value.auto_download,
             auto_update: value.auto_update,
             auto_cleanup: value.auto_cleanup,
@@ -80,6 +83,7 @@ impl From<Setting> for SettingEntity {
     fn from(value: Setting) -> Self {
         Self {
             id: value.id.to_string(),
+            episode_numbering: value.episode_numbering,
             auto_download: value.auto_download,
             auto_update: value.auto_update,
             auto_cleanup: value.auto_cleanup,
@@ -144,6 +148,7 @@ impl SettingRepository for DieselSettingsRepository {
         insert_into(settings)
             .values((
                 id.eq(podfetch_domain::ids::new_id().to_string()),
+                episode_numbering.eq(false),
                 auto_update.eq(true),
                 auto_download.eq(true),
                 auto_cleanup.eq(true),
@@ -184,12 +189,15 @@ mod tests {
         let mut s = repo.get_settings().expect("get").expect("present");
         s.nfo_format = "album".to_string();
         s.cover_filename = "cover".to_string();
+        s.episode_numbering = true;
         let updated = repo.update_settings(s).expect("update");
         assert_eq!(updated.nfo_format, "album");
         assert_eq!(updated.cover_filename, "cover");
+        assert!(updated.episode_numbering);
 
         let reread = repo.get_settings().expect("get").expect("present");
         assert_eq!(reread.nfo_format, "album");
         assert_eq!(reread.cover_filename, "cover");
+        assert!(reread.episode_numbering);
     }
 }

--- a/crates/podfetch-persistence/tests/reconcile_standard_user.rs
+++ b/crates/podfetch-persistence/tests/reconcile_standard_user.rs
@@ -51,25 +51,29 @@ fn cleanup(tmp: &std::path::Path) {
     }
 }
 
-/// Apply every migration EXCEPT the newest one (the reconcile migration), so a
-/// test can plant a pre-reconcile database state, then return that last
-/// migration ready to apply.
+/// Apply every migration ordered BEFORE the reconcile migration, so a test can
+/// plant a pre-reconcile database state, then return the reconcile migration
+/// ready to apply. Migrations newer than reconcile are irrelevant to what
+/// reconcile does and are left unapplied, so this stays correct as later
+/// migrations are added.
 fn apply_through_pre_reconcile(
     conn: &mut SqliteConnection,
 ) -> Box<dyn diesel::migration::Migration<diesel::sqlite::Sqlite>> {
     let pending = conn.pending_migrations(SQLITE_MIGRATIONS).expect("pending");
-    let (reconcile, earlier) = pending.split_last().expect("at least one migration");
-    assert!(
-        reconcile.name().to_string().contains("reconcile_standard_user"),
-        "newest migration must be the reconcile migration, got `{}`",
-        reconcile.name()
-    );
-    for m in earlier {
+    let reconcile_idx = pending
+        .iter()
+        .position(|m| m.name().to_string().contains("reconcile_standard_user"))
+        .expect("reconcile_standard_user migration must be present");
+    for m in &pending[..reconcile_idx] {
         conn.run_migration(m).expect("apply earlier migration");
     }
-    // `pending` is consumed below, so hand back the reconcile migration boxed.
+    // Re-query now that the earlier migrations are applied and hand back the
+    // reconcile migration boxed.
     let pending = conn.pending_migrations(SQLITE_MIGRATIONS).expect("pending");
-    pending.into_iter().next_back().expect("reconcile migration")
+    pending
+        .into_iter()
+        .find(|m| m.name().to_string().contains("reconcile_standard_user"))
+        .expect("reconcile migration")
 }
 
 fn fk_violations(conn: &mut SqliteConnection) -> i64 {

--- a/crates/podfetch-web/src/controllers/podcast_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_controller.rs
@@ -865,6 +865,7 @@ pub async fn retrieve_podcast_sample_format(
     };
     let settings = Setting {
         id: uuid::Uuid::nil().to_string(),
+        episode_numbering: false,
         auto_download: false,
         auto_update: false,
         auto_cleanup: false,

--- a/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
+++ b/crates/podfetch-web/src/controllers/podcast_episode_controller.rs
@@ -539,6 +539,7 @@ pub async fn retrieve_episode_sample_format(
     };
     let settings = Setting {
         id: uuid::Uuid::nil().to_string(),
+        episode_numbering: false,
         auto_download: false,
         auto_update: false,
         auto_cleanup: false,

--- a/crates/podfetch-web/src/controllers/settings_controller.rs
+++ b/crates/podfetch-web/src/controllers/settings_controller.rs
@@ -604,6 +604,7 @@ mod tests {
             Extension(user.clone()),
             Json(Setting {
                 id: uuid::Uuid::new_v4().to_string(),
+                episode_numbering: false,
                 auto_download: true,
                 auto_update: true,
                 auto_cleanup: false,

--- a/crates/podfetch-web/src/services/download/service.rs
+++ b/crates/podfetch-web/src/services/download/service.rs
@@ -2,6 +2,7 @@ use crate::services::download::chapter::{Chapter, Link};
 use crate::services::file::service::{FileService, prepare_podcast_episode_title_to_directory};
 use crate::services::podcast_episode_chapter::service::PodcastEpisodeChapterService;
 use crate::services::podcast_settings::service::PodcastSettingsService;
+use crate::services::settings::service::SettingsService;
 use podfetch_persistence::podcast::PodcastEntity as Podcast;
 use podfetch_persistence::podcast_episode::PodcastEpisodeEntity as PodcastEpisode;
 use std::fs::File;
@@ -488,12 +489,7 @@ impl DownloadService {
             parse_id(&podcast_episode.podcast_id)?,
         )?;
 
-        let settings_for_podcast =
-            PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
-        let numbering_enabled = settings_for_podcast
-            .as_ref()
-            .map(|s| s.episode_numbering)
-            .unwrap_or(false);
+        let numbering_enabled = Self::episode_numbering_enabled(parse_id(&podcast.id)?)?;
         if let Some((title, processed)) = Self::resolve_episode_title(
             &podcast_episode.name,
             podcast_episode.episode_numbering_processed,
@@ -568,12 +564,7 @@ impl DownloadService {
                     &podcast_episode.date_of_recording,
                     parse_id(&podcast_episode.podcast_id)?,
                 )?;
-                let settings_for_podcast =
-                    PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
-                let numbering_enabled = settings_for_podcast
-                    .as_ref()
-                    .map(|s| s.episode_numbering)
-                    .unwrap_or(false);
+                let numbering_enabled = Self::episode_numbering_enabled(parse_id(&podcast.id)?)?;
                 if let Some((title, processed)) = Self::resolve_episode_title(
                     &podcast_episode.name,
                     podcast_episode.episode_numbering_processed,
@@ -624,6 +615,29 @@ impl DownloadService {
                 Ok(())
             }
         }
+    }
+
+    /// Resolve whether episode-number title prefixing applies to a podcast.
+    ///
+    /// The per-podcast `episode_numbering` flag is OR-ed with the instance-wide
+    /// default from the global settings, so enabling numbering in general
+    /// settings turns it on for every podcast unless it is already on per
+    /// podcast. This mirrors how `auto_download` layers the per-podcast value
+    /// over the global default.
+    fn episode_numbering_enabled(podcast_id: uuid::Uuid) -> Result<bool, CustomError> {
+        let per_podcast =
+            PodcastSettingsService::get_settings_for_podcast(podcast_id)?.map(|s| s.episode_numbering);
+        let global = SettingsService::shared()
+            .get_settings()?
+            .map(|s| s.episode_numbering);
+        Ok(Self::numbering_from(per_podcast, global))
+    }
+
+    /// Combine the per-podcast and instance-wide `episode_numbering` flags.
+    /// Numbering applies when either layer turns it on; a missing settings row
+    /// counts as "off" for that layer.
+    fn numbering_from(per_podcast: Option<bool>, global: Option<bool>) -> bool {
+        per_podcast.unwrap_or(false) || global.unwrap_or(false)
     }
 
     /// Decide the title to embed and whether to (re)write the
@@ -780,6 +794,19 @@ mod tests {
             super::DownloadService::resolve_episode_title("Ep", true, false, 5),
             Some(("Ep".to_string(), false))
         );
+    }
+
+    #[test]
+    fn numbering_from_ors_per_podcast_and_global_default() {
+        // global default forces numbering even with no per-podcast row or an explicit off
+        assert!(DownloadService::numbering_from(None, Some(true)));
+        assert!(DownloadService::numbering_from(Some(false), Some(true)));
+        // per-podcast enables it regardless of the (off/absent) global default
+        assert!(DownloadService::numbering_from(Some(true), Some(false)));
+        assert!(DownloadService::numbering_from(Some(true), None));
+        // both layers off / absent -> disabled
+        assert!(!DownloadService::numbering_from(Some(false), Some(false)));
+        assert!(!DownloadService::numbering_from(None, None));
     }
 
     #[test]

--- a/crates/podfetch-web/src/services/file/service.rs
+++ b/crates/podfetch-web/src/services/file/service.rs
@@ -518,6 +518,7 @@ mod tests {
         let title = "test: test";
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -549,6 +550,7 @@ mod tests {
         let title = "test: test";
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -580,6 +582,7 @@ mod tests {
         let title = "test: test";
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -610,6 +613,7 @@ mod tests {
     fn test_podcast_episode_replacement_guid() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -659,6 +663,7 @@ mod tests {
     fn test_podcast_episode_replacement_title() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -708,6 +713,7 @@ mod tests {
     fn test_podcast_episode_replacement_old_format() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -757,6 +763,7 @@ mod tests {
     fn episode_format_supports_episode_number_token() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -806,6 +813,7 @@ mod tests {
     pub fn perform_podcast_variable_replacement_date_title() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,
@@ -842,6 +850,7 @@ mod tests {
     pub fn perform_podcast_variable_replacement_old_format() {
         let settings = Setting {
             id: uuid::Uuid::nil(),
+            episode_numbering: false,
             auto_download: false,
             auto_update: false,
             auto_cleanup: false,

--- a/crates/podfetch-web/src/services/settings/service.rs
+++ b/crates/podfetch-web/src/services/settings/service.rs
@@ -94,6 +94,7 @@ impl SettingsService {
 fn build_name_only_setting(update: &UpdateNameSettings) -> podfetch_domain::settings::Setting {
     podfetch_domain::settings::Setting {
         id: uuid::Uuid::nil(),
+        episode_numbering: false,
         auto_download: false,
         auto_update: false,
         auto_cleanup: false,

--- a/crates/podfetch-web/src/settings.rs
+++ b/crates/podfetch-web/src/settings.rs
@@ -10,6 +10,10 @@ use xml_builder::{XMLBuilder, XMLElement, XMLVersion};
 #[serde(rename_all = "camelCase")]
 pub struct Setting {
     pub id: String,
+    /// Instance-wide default for episode-number title prefixing. Defaulted on
+    /// deserialize so older clients that omit it keep working.
+    #[serde(default)]
+    pub episode_numbering: bool,
     pub auto_download: bool,
     pub auto_update: bool,
     pub auto_cleanup: bool,
@@ -58,6 +62,7 @@ impl From<podfetch_domain::settings::Setting> for Setting {
     fn from(value: podfetch_domain::settings::Setting) -> Self {
         Self {
             id: value.id.to_string(),
+            episode_numbering: value.episode_numbering,
             auto_download: value.auto_download,
             auto_update: value.auto_update,
             auto_cleanup: value.auto_cleanup,
@@ -83,6 +88,7 @@ impl From<Setting> for podfetch_domain::settings::Setting {
     fn from(value: Setting) -> Self {
         Self {
             id: Uuid::parse_str(&value.id).unwrap_or_else(|_| Uuid::nil()),
+            episode_numbering: value.episode_numbering,
             auto_download: value.auto_download,
             auto_update: value.auto_update,
             auto_cleanup: value.auto_cleanup,

--- a/migrations/postgres/2026-06-25-120000_settings_episode_numbering/down.sql
+++ b/migrations/postgres/2026-06-25-120000_settings_episode_numbering/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings DROP COLUMN episode_numbering;

--- a/migrations/postgres/2026-06-25-120000_settings_episode_numbering/up.sql
+++ b/migrations/postgres/2026-06-25-120000_settings_episode_numbering/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN episode_numbering BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sqlite/2026-06-25-120000_settings_episode_numbering/down.sql
+++ b/migrations/sqlite/2026-06-25-120000_settings_episode_numbering/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings DROP COLUMN episode_numbering;

--- a/migrations/sqlite/2026-06-25-120000_settings_episode_numbering/up.sql
+++ b/migrations/sqlite/2026-06-25-120000_settings_episode_numbering/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN episode_numbering BOOLEAN NOT NULL DEFAULT FALSE;

--- a/mobile/schema.d.ts
+++ b/mobile/schema.d.ts
@@ -1725,6 +1725,8 @@ export interface components {
             autoUpdate: boolean;
             directPaths: boolean;
             episodeFormat: string;
+            /** @description Defaulted on deserialize so older clients that omit it keep working. */
+            episodeNumbering?: boolean;
             id: string;
             /** Format: int32 */
             maxParallelDownloads?: number;

--- a/ui/schema.d.ts
+++ b/ui/schema.d.ts
@@ -1871,6 +1871,8 @@ export interface components {
             autoUpdate: boolean;
             directPaths: boolean;
             episodeFormat: string;
+            /** @description Defaulted on deserialize so older clients that omit it keep working. */
+            episodeNumbering?: boolean;
             id: string;
             /**
              * Format: int32

--- a/ui/src/components/SettingsData.tsx
+++ b/ui/src/components/SettingsData.tsx
@@ -68,6 +68,16 @@ export const Settings = () => {
                 </div>
 
                 <div className="flex flex-col gap-2 xs:contents mb-4">
+                    <label htmlFor="episode-numbering" className="flex gap-1">{t('episode-numbering')} <SettingsInfoIcon headerKey="episode-numbering" textKey="episode-numbering-explanation" /></label>
+                    <Switcher loading={settingsModel.isLoading} checked={settingsModel.data?.episodeNumbering} className="xs:justify-self-end" id="episode-numbering" onChange={() => {
+                        queryClient.setQueryData(['get', '/api/v1/settings'], (oldData: Setting) => ({
+                            ...oldData,
+                            episodeNumbering: !oldData?.episodeNumbering
+                        }))
+                    }} />
+                </div>
+
+                <div className="flex flex-col gap-2 xs:contents mb-4">
                     <label htmlFor="number-of-podcasts-to-download" className="flex gap-1">{t('number-of-podcasts-to-download')} <SettingsInfoIcon headerKey="number-of-podcasts-to-download" textKey="number-of-podcasts-to-download-explanation" /></label>
                     <CustomInput loading={settingsModel.isLoading} className="w-20" id="number-of-podcasts-to-download" onChange={(e) => {
                         queryClient.setQueryData(['get', '/api/v1/settings'], (oldData: Setting) => ({

--- a/ui/src/language/json/de.json
+++ b/ui/src/language/json/de.json
@@ -270,6 +270,7 @@
   "user-settings-updated": "Benutzereinstellungen aktualisiert",
   "notification.episode-now-available": "Episode {{episode}} ist jetzt verfügbar",
   "episode-numbering": "Episodennummerierung",
+  "episode-numbering-explanation": "Stellt jeder Episode ihre fortlaufende Nummer im Titel voran, damit Player sie in der richtigen Reihenfolge anzeigen. Gilt standardmäßig für alle Podcasts; einzelne Podcasts können es weiterhin in ihren eigenen Einstellungen aktivieren.",
   "activated": "Aktiviert",
   "manage-gpodder-podcasts": "GPodder Podcasts verwalten",
   "device": "Gerät",

--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -268,6 +268,7 @@
   "user-settings-updated": "User settings updated",
   "notification.episode-now-available": "Episode {{episode}} now available",
   "episode-numbering": "Episode numbering",
+  "episode-numbering-explanation": "Prefixes each episode's title with its sequential number so players keep them in the correct order. Applies to all podcasts by default; individual podcasts can still enable it in their own settings.",
   "activated": "Activated",
   "manage-gpodder-podcasts": "Manage GPodder podcasts",
   "tag_one": "Tag",

--- a/ui/src/models/Setting.tsx
+++ b/ui/src/models/Setting.tsx
@@ -1,5 +1,6 @@
 export type Setting = {
     id: string,
+    episodeNumbering: boolean,
     autoDownload: boolean,
     autoUpdate: boolean,
     autoCleanup: boolean,


### PR DESCRIPTION
## What

Adds an **Episode numbering** toggle to the general (instance-wide) settings. Until now this option only existed in per-podcast settings.

Closes #2139

## How

The global flag is a **default that is OR-ed with the per-podcast flag**, mirroring how `auto_download` already layers the per-podcast value over the global default (`podcast_settings.auto_download || settings.auto_download`).

- Numbering applies if **either** the per-podcast flag **or** the new global default enables it.
- The decision lives in `download/service.rs::episode_numbering_enabled`, delegating to a pure, unit-tested `numbering_from(per_podcast, global)` helper that replaces the two previously-duplicated inline blocks (ID3 + MP4 metadata paths).

## Changes

- **Migrations:** add `episode_numbering BOOLEAN NOT NULL DEFAULT FALSE` to the `settings` table (sqlite + postgres, with `down`).
- **Backend:** field threaded through the domain `Setting`, persistence (`table!` + `SettingEntity` + conversions + `insert_default_settings`), and the web DTO (`#[serde(default)]` for backward compatibility).
- **Frontend:** toggle on the general settings page with an explanatory tooltip; TS model + both `schema.d.ts` updated (field rendered optional to match the `#[serde(default)]` generator output); `en` + `de` translations added (other locales fall back to English).
- **Tests:** persistence round-trip extended; new truth-table unit test for the OR logic.

## Behavior note

Like other global settings, the flag applies **going forward** (new downloads / metadata insertion / rescan), not retroactively on save.

## Verification

- `cargo clippy --no-default-features --features sqlite --all-targets -- -D warnings` ✅
- Targeted tests (persistence + download + settings/podcast controllers, sqlite) ✅
- `tsc --noEmit` for the UI ✅