### PR TITLE
fix: inherit general settings as per-podcast defaults (#2141)

### DIFF
--- a/crates/podfetch-web/src/services/download/service.rs
+++ b/crates/podfetch-web/src/services/download/service.rs
@@ -208,10 +208,12 @@ impl DownloadService {
             .unwrap();
         let podcast_settings_override =
             PodcastSettingsService::get_settings_for_podcast(parse_id(&podcast.id)?)?;
-        let use_one_cover_for_all_episodes = podcast_settings_override
-            .as_ref()
-            .map(|s| s.use_one_cover_for_all_episodes)
-            .unwrap_or(settings_in_db.use_one_cover_for_all_episodes);
+        let use_one_cover_for_all_episodes = Self::use_one_cover_from(
+            podcast_settings_override
+                .as_ref()
+                .map(|s| (s.activated, s.use_one_cover_for_all_episodes)),
+            settings_in_db.use_one_cover_for_all_episodes,
+        );
         let should_download_main_image = !use_one_cover_for_all_episodes
             && !FileService::check_if_podcast_main_image_downloaded(
                 &podcast.clone().directory_id,
@@ -640,6 +642,18 @@ impl DownloadService {
         per_podcast.unwrap_or(false) || global.unwrap_or(false)
     }
 
+    /// Resolve the effective `use_one_cover_for_all_episodes`. The per-podcast
+    /// value is honoured only when its settings row is activated; otherwise the
+    /// instance-wide default applies. This mirrors `resolve_nfo_format` /
+    /// `resolve_cover_filename` so every per-podcast download option shares the
+    /// same `activated`-gated override rule. `per_podcast` is `(activated, value)`.
+    fn use_one_cover_from(per_podcast: Option<(bool, bool)>, global: bool) -> bool {
+        match per_podcast {
+            Some((activated, value)) if activated => value,
+            _ => global,
+        }
+    }
+
     /// Decide the title to embed and whether to (re)write the
     /// `episode_numbering_processed` flag. Returns `None` when numbering is on
     /// and the episode was already processed (leave the existing title alone).
@@ -807,6 +821,21 @@ mod tests {
         // both layers off / absent -> disabled
         assert!(!DownloadService::numbering_from(Some(false), Some(false)));
         assert!(!DownloadService::numbering_from(None, None));
+    }
+
+    #[test]
+    fn use_one_cover_from_respects_activated_gate() {
+        // no per-podcast row -> instance-wide default applies
+        assert!(DownloadService::use_one_cover_from(None, true));
+        assert!(!DownloadService::use_one_cover_from(None, false));
+        // per-podcast row but NOT activated -> still falls back to the global
+        // default (mirrors NFO/cover resolution; the activated flag is the
+        // explicit-override switch).
+        assert!(DownloadService::use_one_cover_from(Some((false, false)), true));
+        assert!(!DownloadService::use_one_cover_from(Some((false, true)), false));
+        // per-podcast row activated -> the per-podcast value wins
+        assert!(DownloadService::use_one_cover_from(Some((true, true)), false));
+        assert!(!DownloadService::use_one_cover_from(Some((true, false)), true));
     }
 
     #[test]

--- a/ui/src/components/PodcastSettingsModal.tsx
+++ b/ui/src/components/PodcastSettingsModal.tsx
@@ -41,6 +41,11 @@ export const PodcastSettingsModal: FC<PodcastSettingsModalProps> = ({
         }
     )
 
+    // The instance-wide settings act as the fallback the backend applies when a
+    // podcast has no activated override, so seed the draft from them rather than
+    // from hardcoded constants (see issue #2141).
+    const globalSettingsQuery = $api.useQuery('get', '/api/v1/settings')
+
     const updateSettings = $api.useMutation(
         'put',
         '/api/v1/podcasts/{id}/settings'
@@ -80,10 +85,10 @@ export const PodcastSettingsModal: FC<PodcastSettingsModalProps> = ({
     useEffect(() => {
         if (settingsQuery.data) {
             setDraft(settingsQuery.data)
-        } else if (!settingsQuery.isLoading) {
-            setDraft(generatePodcastDefaultSettings(podcast.id))
+        } else if (!settingsQuery.isLoading && !globalSettingsQuery.isLoading) {
+            setDraft(generatePodcastDefaultSettings(podcast.id, globalSettingsQuery.data))
         }
-    }, [settingsQuery.data, settingsQuery.isLoading, podcast.id])
+    }, [settingsQuery.data, settingsQuery.isLoading, globalSettingsQuery.data, globalSettingsQuery.isLoading, podcast.id])
 
     const update = <K extends keyof PodcastSetting>(
         key: K,

--- a/ui/src/models/PodcastDefaultSettings.test.ts
+++ b/ui/src/models/PodcastDefaultSettings.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { generatePodcastDefaultSettings } from './PodcastDefaultSettings'
+import { Setting } from './Setting'
+
+const globalSettings: Setting = {
+    id: 'global',
+    episodeNumbering: true,
+    autoDownload: false,
+    autoUpdate: false,
+    autoCleanup: true,
+    autoCleanupDays: 14,
+    podcastPrefill: 5,
+    useExistingFilename: true,
+    replaceInvalidCharacters: true,
+    replacementStrategy: 'remove',
+    episodeFormat: '{episodeTitle}',
+    podcastFormat: '{podcastTitle}',
+    directPaths: true,
+    autoTranscodeOpus: false,
+    useOneCoverForAllEpisodes: true,
+    nfoFormat: 'album',
+    coverFilename: 'cover',
+    maxParallelDownloads: 3,
+}
+
+describe('generatePodcastDefaultSettings', () => {
+    it('inherits the inheritable fields from the global settings', () => {
+        const result = generatePodcastDefaultSettings('podcast-1', globalSettings)
+
+        expect(result.podcastId).toBe('podcast-1')
+        // never auto-activated: the user must explicitly opt into an override
+        expect(result.activated).toBe(false)
+        // fields the bug report is about must reflect the global defaults
+        expect(result.nfoFormat).toBe('album')
+        expect(result.coverFilename).toBe('cover')
+        expect(result.useOneCoverForAllEpisodes).toBe(true)
+        // the rest of the overlapping fields inherit too
+        expect(result.episodeNumbering).toBe(true)
+        expect(result.autoDownload).toBe(false)
+        expect(result.autoUpdate).toBe(false)
+        expect(result.autoCleanup).toBe(true)
+        expect(result.autoCleanupDays).toBe(14)
+        expect(result.podcastPrefill).toBe(5)
+        expect(result.useExistingFilename).toBe(true)
+        expect(result.replaceInvalidCharacters).toBe(true)
+        expect(result.replacementStrategy).toBe('remove')
+        expect(result.episodeFormat).toBe('{episodeTitle}')
+        expect(result.podcastFormat).toBe('{podcastTitle}')
+        expect(result.directPaths).toBe(true)
+    })
+
+    it('falls back to the built-in defaults when global settings are unavailable', () => {
+        const result = generatePodcastDefaultSettings('podcast-2')
+
+        expect(result.podcastId).toBe('podcast-2')
+        expect(result.activated).toBe(false)
+        expect(result.nfoFormat).toBe('off')
+        expect(result.coverFilename).toBe('image')
+        expect(result.useOneCoverForAllEpisodes).toBe(false)
+        expect(result.autoDownload).toBe(true)
+        expect(result.autoUpdate).toBe(true)
+        expect(result.replacementStrategy).toBe('replace-with-dash-and-underscore')
+    })
+})

--- a/ui/src/models/PodcastDefaultSettings.tsx
+++ b/ui/src/models/PodcastDefaultSettings.tsx
@@ -1,23 +1,33 @@
 import {components} from "../../schema";
 
-export const generatePodcastDefaultSettings = (podcastId: string) => {
+/**
+ * Build the per-podcast settings shown when a podcast has no explicit override
+ * row yet. The override is never auto-activated (`activated: false`), but the
+ * displayed values inherit from the instance-wide settings so the modal matches
+ * what the backend actually applies as the fallback. When the global settings
+ * are unavailable the built-in defaults are used instead.
+ */
+export const generatePodcastDefaultSettings = (
+    podcastId: string,
+    globalSettings?: components['schemas']['Setting']
+) => {
     return {
         activated: false,
-        autoCleanup: false,
-        autoCleanupDays: 0,
-        autoDownload: true,
-        autoUpdate: true,
-        directPaths: false,
-        episodeFormat: "",
-        episodeNumbering: false,
-        podcastFormat: "",
         podcastId: podcastId,
-        podcastPrefill: 0,
-        replaceInvalidCharacters: false,
-        replacementStrategy: "replace-with-dash-and-underscore",
-        useExistingFilename: false,
-        useOneCoverForAllEpisodes: false,
-        nfoFormat: "off",
-        coverFilename: "image"
+        autoCleanup: globalSettings?.autoCleanup ?? false,
+        autoCleanupDays: globalSettings?.autoCleanupDays ?? 0,
+        autoDownload: globalSettings?.autoDownload ?? true,
+        autoUpdate: globalSettings?.autoUpdate ?? true,
+        directPaths: globalSettings?.directPaths ?? false,
+        episodeFormat: globalSettings?.episodeFormat ?? "",
+        episodeNumbering: globalSettings?.episodeNumbering ?? false,
+        podcastFormat: globalSettings?.podcastFormat ?? "",
+        podcastPrefill: globalSettings?.podcastPrefill ?? 0,
+        replaceInvalidCharacters: globalSettings?.replaceInvalidCharacters ?? false,
+        replacementStrategy: globalSettings?.replacementStrategy ?? "replace-with-dash-and-underscore",
+        useExistingFilename: globalSettings?.useExistingFilename ?? false,
+        useOneCoverForAllEpisodes: globalSettings?.useOneCoverForAllEpisodes ?? false,
+        nfoFormat: globalSettings?.nfoFormat ?? "off",
+        coverFilename: globalSettings?.coverFilename ?? "image"
     } satisfies components['schemas']['PodcastSetting']
 }


### PR DESCRIPTION
Fixes #2141.

General settings were applied by the backend as the fallback for podcasts without an activated override, but the per-podcast settings modal seeded its form from hardcoded constants. This caused the reported contradictions: `album.nfo` written while the modal showed "No NFO files", and one-cover-for-all functionally on while shown disabled.

## Root cause
- The per-podcast settings modal fell back to `generatePodcastDefaultSettings`, which returned hardcoded values (`nfoFormat: "off"`, `coverFilename: "image"`, `useOneCoverForAllEpisodes: false`) whenever a podcast had no override row (`GET /podcasts/{id}/settings` returns 404 for fresh podcasts) — ignoring the global settings the backend actually applies.
- `use_one_cover_for_all_episodes` in the download path used the per-podcast value whenever a row existed, unlike `resolve_nfo_format` / `resolve_cover_filename`, which only honor a per-podcast value when `activated`.

## Changes
- **UI**: `generatePodcastDefaultSettings` now inherits all overlapping fields from the instance-wide settings (still `activated: false`, so overrides stay opt-in), falling back to built-in defaults when globals are unavailable. The modal fetches `/api/v1/settings` and passes them in.
- **Backend**: `use_one_cover_for_all_episodes` now respects the per-podcast `activated` gate via a shared `use_one_cover_from` helper, matching the NFO/cover resolvers so the resolution rules can't drift.

## Tests
Both changes covered by tests written test-first:
- `crates/podfetch-web/.../download/service.rs`: `use_one_cover_from_respects_activated_gate`
- `ui/src/models/PodcastDefaultSettings.test.ts`: inheritance + fallback cases

Verified: `cargo test -p podfetch-web --features sqlite` (download + nfo modules green), `vitest run` (2/2), `tsc --noEmit` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)