### PR TITLE
test(e2e): cover settings, theming, i18n, playlists and core feature pages

### DIFF
--- a/ui/e2e/tests/features.spec.ts
+++ b/ui/e2e/tests/features.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test'
+import { readSeed } from '../helpers'
+
+const seed = readSeed()
+
+test('favoriting a podcast lists it on the favorites page', async ({ page }) => {
+    await page.goto('/ui/podcasts')
+    await expect(page.getByText('Transcript E2E Podcast', { exact: true })).toBeVisible()
+
+    // The sidebar's Favorites entry also uses a heart icon; the card's heart
+    // is the absolutely positioned one on the cover image.
+    await page.locator('svg.lucide-heart.absolute').click()
+
+    await expect(async () => {
+        await page.goto('/ui/favorites')
+        await expect(page.getByText('Transcript E2E Podcast', { exact: true })).toBeVisible({
+            timeout: 2_000,
+        })
+    }).toPass({ timeout: 15_000 })
+
+    // Unfavor again so the favorites page returns to its empty state.
+    await page.locator('svg.lucide-heart.absolute').click()
+    await expect(async () => {
+        await page.goto('/ui/favorites')
+        await expect(page.getByText('Transcript E2E Podcast', { exact: true })).not.toBeVisible({
+            timeout: 2_000,
+        })
+    }).toPass({ timeout: 15_000 })
+})
+
+test('timeline shows the downloaded fixture episodes', async ({ page }) => {
+    await page.goto('/ui/timeline')
+
+    // "Only favorite podcasts" is on by default; the fixture podcast is not
+    // favored, so widen the filter first.
+    await page
+        .getByText('Only favorite podcasts', { exact: true })
+        .locator('xpath=following-sibling::*[1]')
+        .click()
+
+    await expect(page.getByText('Smoke Episode 1', { exact: true }).first()).toBeVisible()
+})
+
+test('episodes archive lists downloaded episodes', async ({ page }) => {
+    await page.goto('/ui/episodes')
+
+    await expect(page.getByText('Smoke Episode 1', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('Plain Episode 2', { exact: true }).first()).toBeVisible()
+})
+
+test('statistics page renders its charts', async ({ page }) => {
+    await page.goto('/ui/stats')
+
+    // The listening-behavior chart axes carry translated weekday labels.
+    await expect(page.getByText('Monday').first()).toBeVisible()
+})
+
+test('inbox page renders', async ({ page }) => {
+    await page.goto('/ui/inbox')
+
+    await expect(page.getByRole('heading').first()).toBeVisible()
+})
+
+test('a playlist can be created through the three-step wizard', async ({ page }) => {
+    await page.goto('/ui/home/playlist')
+
+    await page.getByRole('button', { name: 'Add new' }).click()
+    const dialog = page.getByRole('dialog')
+
+    // Stage 1: name.
+    await dialog.locator('#playlist-name').fill('E2E Test Playlist')
+    await dialog.getByRole('button', { name: 'Next' }).click()
+
+    // Stage 2: pick an episode via the embedded search.
+    await dialog.locator('#search-input').fill('Smoke Episode')
+    await dialog.getByText('Smoke Episode 1', { exact: true }).first().click()
+    await dialog.getByRole('button', { name: 'Next' }).click()
+
+    // Stage 3: the review step names the playlist; submit it.
+    await expect(dialog.getByText('E2E Test Playlist').first()).toBeVisible()
+    await dialog.getByRole('button', { name: 'Create playlist' }).click()
+
+    await expect(page.getByText('E2E Test Playlist', { exact: true }).first()).toBeVisible({
+        timeout: 15_000,
+    })
+    await expect(page.getByText('1 items').first()).toBeVisible()
+
+    // Opening the playlist shows its episode ("Open" exact, to not match the
+    // header's "Open notifications" button).
+    await page.getByRole('button', { name: 'Open', exact: true }).first().click()
+    await expect(page.getByText('Smoke Episode 1', { exact: true }).first()).toBeVisible()
+})
+
+test('user menu exposes profile and administration entries', async ({ page }) => {
+    await page.goto(`/ui/podcasts/${seed.podcastId}/episodes`)
+
+    await page.locator('svg.lucide-circle-user-round').first().locator('xpath=ancestor::button[1]').click()
+    await expect(page.getByText('Profile', { exact: true })).toBeVisible()
+    await expect(page.getByText('System information', { exact: true })).toBeVisible()
+    await expect(page.getByText('User Administration', { exact: true })).toBeVisible()
+})

--- a/ui/e2e/tests/settings.spec.ts
+++ b/ui/e2e/tests/settings.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+
+test('retention settings persist across reloads', async ({ page }) => {
+    await page.goto('/ui/settings/retention')
+
+    const daysToKeep = page.locator('#days-to-keep')
+    await expect(daysToKeep).toBeVisible()
+    const original = await daysToKeep.inputValue()
+
+    await daysToKeep.fill('31')
+    await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.getByText('Settings saved')).toBeVisible()
+
+    await page.reload()
+    await expect(daysToKeep).toHaveValue('31')
+
+    // Restore the original value so later suites see pristine settings.
+    await daysToKeep.fill(original)
+    await page.getByRole('button', { name: 'Save' }).click()
+    await expect(page.getByText('Settings saved')).toBeVisible()
+})
+
+test('naming settings page renders its configuration controls', async ({ page }) => {
+    await page.goto('/ui/settings/naming')
+
+    await expect(page.getByText('Colon replacement')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+})
+
+test('opml export downloads a feed list', async ({ page }) => {
+    await page.goto('/ui/settings/opml')
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Download' }).first().click()
+    const download = await downloadPromise
+
+    expect(download.suggestedFilename()).toBe('podcast_local.opml')
+})
+
+test('theme selection applies dark mode and survives reloads', async ({ page }) => {
+    await page.goto('/ui/podcasts')
+
+    const isDark = () => page.evaluate(() => document.documentElement.classList.contains('dark'))
+
+    await page.getByRole('button', { name: 'Dark', exact: true }).click()
+    expect(await isDark()).toBe(true)
+
+    await page.reload()
+    expect(await isDark()).toBe(true)
+
+    await page.getByRole('button', { name: 'Light', exact: true }).click()
+    expect(await isDark()).toBe(false)
+
+    // Back to the default system preference.
+    await page.getByRole('button', { name: 'System', exact: true }).click()
+})
+
+test('language can be switched and translates the ui', async ({ page }) => {
+    await page.goto('/ui/podcasts/search')
+    await expect(page.getByRole('heading', { name: 'Search episodes' })).toBeVisible()
+
+    await page.locator('.i18n-dropdown').click()
+    await page.getByRole('option', { name: 'Deutsch' }).click()
+    await expect(page.getByRole('heading', { name: 'Episoden suchen' })).toBeVisible()
+
+    // And back to English for the rest of the suite.
+    await page.locator('.i18n-dropdown').click()
+    await page.getByRole('option', { name: 'English' }).click()
+    await expect(page.getByRole('heading', { name: 'Search episodes' })).toBeVisible()
+})
+
+test('notifications popover opens and reports its state', async ({ page }) => {
+    await page.goto('/ui/podcasts')
+
+    await page.getByRole('button', { name: 'Open notifications' }).click()
+    // Feed refreshes create real notifications, so accept either the unread
+    // header or the empty state.
+    await expect(page.getByText(/unread notifications|No notifications/).first()).toBeVisible()
+})

--- a/ui/src/components/CreatePlaylistModal.tsx
+++ b/ui/src/components/CreatePlaylistModal.tsx
@@ -245,7 +245,13 @@ export const CreatePlaylistModal: FC<CreatePlaylistModalProps> = ({ open, onOpen
                             </CustomButtonSecondary>
                         )}
                         {stage < 2 ? (
+                            // Distinct keys keep React from reusing the same DOM
+                            // node for Next and the submit button: with a shared
+                            // node, clicking Next re-renders it to type="submit"
+                            // before the browser runs the click's default action,
+                            // submitting the form and skipping the review step.
                             <CustomButtonPrimary
+                                key="wizard-next"
                                 type="button"
                                 onClick={goNext}
                                 disabled={stage === 0 && !canMoveToStageTwo}
@@ -256,7 +262,7 @@ export const CreatePlaylistModal: FC<CreatePlaylistModalProps> = ({ open, onOpen
                                 </span>
                             </CustomButtonPrimary>
                         ) : (
-                            <CustomButtonPrimary type="submit" loading={isSubmitting} disabled={!canSubmit}>
+                            <CustomButtonPrimary key="wizard-submit" type="submit" loading={isSubmitting} disabled={!canSubmit}>
                                 {watchedId === "-1" ? t('create-playlist') : t('update-playlist')}
                             </CustomButtonPrimary>
                         )}


### PR DESCRIPTION
## Summary

Follow-up to #2181 — this commit was pushed to the feature branch a few minutes after the squash-merge and didn't make it into main.

- **settings.spec.ts**: retention persistence across reloads, naming page, OPML export download, theme selection (incl. reload persistence), language switching, notifications popover
- **features.spec.ts**: podcast favoriting via the favorites page, timeline filter, episodes archive, statistics, inbox, the full three-step playlist wizard, user menu entries
- **Bugfix (playlist wizard)**: React reused the footer button's DOM node when advancing to the review step, so the browser ran the click's default action on what had just become a `type=submit` button — submitting the form and skipping the review step entirely. Distinct `key`s per button fix it; the new wizard test guards it.

## Test plan

- [x] Full playwright suite locally: 31/31 passed (~1.7 min)
- [x] vitest + tsc + UI build clean
- [ ] Playwright E2E CI job on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)