### PR TITLE
fix: apply configured cover filename on download and rescan

### DIFF
--- a/crates/podfetch-web/src/services/download/service.rs
+++ b/crates/podfetch-web/src/services/download/service.rs
@@ -16,7 +16,7 @@ use common_infrastructure::error::{
 use common_infrastructure::http::COMMON_USER_AGENT;
 use common_infrastructure::http::{get_async_sync_client, get_sync_client};
 use common_infrastructure::runtime::{
-    DEFAULT_IMAGE_URL, ENVIRONMENT_SERVICE, PODCAST_FILENAME, PODCAST_IMAGENAME,
+    DEFAULT_IMAGE_URL, ENVIRONMENT_SERVICE, PODCAST_FILENAME,
 };
 use file_format::FileFormat;
 use id3::{ErrorKind, Tag, TagLike};
@@ -252,6 +252,8 @@ impl DownloadService {
         };
 
         let episode_stem = prepare_podcast_episode_title_to_directory(podcast_episode.clone())?;
+        let cover_filename =
+            crate::services::nfo::service::resolve_cover_filename(parse_id(&podcast.id)?);
         let paths = FilenameBuilder::default()
             .with_podcast_directory(&podcast.directory_name)
             .with_episode_stem(&episode_stem)
@@ -262,7 +264,7 @@ impl DownloadService {
                     .map(|data| data.0.clone())
                     .unwrap_or_else(|| "jpg".to_string()),
             )
-            .with_image_filename(PODCAST_IMAGENAME)
+            .with_image_filename(&cover_filename)
             .with_filename(PODCAST_FILENAME)
             .with_direct_paths(settings_in_db.direct_paths)
             .build(|directory| {

--- a/crates/podfetch-web/src/services/episode_rescan/service.rs
+++ b/crates/podfetch-web/src/services/episode_rescan/service.rs
@@ -5,7 +5,7 @@ use crate::services::settings::service::SettingsService;
 use crate::usecases::podcast_episode::PodcastEpisodeUseCase as PodcastEpisodeService;
 use common_infrastructure::config::FileHandlerType;
 use common_infrastructure::error::{CustomError, CustomErrorInner, ErrorSeverity};
-use common_infrastructure::runtime::{PODCAST_FILENAME, PODCAST_IMAGENAME};
+use common_infrastructure::runtime::PODCAST_FILENAME;
 use podfetch_persistence::podcast::PodcastEntity as Podcast;
 use podfetch_persistence::podcast_episode::PodcastEpisodeEntity as PodcastEpisode;
 use podfetch_storage::{FileHandleWrapper, FileRequest, FilenameBuilder, FilenameBuilderReturn};
@@ -392,6 +392,10 @@ impl EpisodeRescanService {
         let image_suffix = extension_lower(current_image_path).unwrap_or_else(|| "jpg".to_string());
 
         let episode_stem = prepare_podcast_episode_title_to_directory(episode.clone())?;
+        let cover_filename = crate::services::nfo::service::resolve_cover_filename(
+            uuid::Uuid::parse_str(&episode.podcast_id)
+                .map_err(|_| CustomError::from(CustomErrorInner::NotFound(ErrorSeverity::Warning)))?,
+        );
 
         // When `direct_paths` is off, FilenameBuilder calls into our
         // resolver to find a free `<stem>-<n>` directory. If the episode
@@ -414,7 +418,7 @@ impl EpisodeRescanService {
             .with_episode_stem(&episode_stem)
             .with_suffix(&suffix)
             .with_image_suffix(&image_suffix)
-            .with_image_filename(PODCAST_IMAGENAME)
+            .with_image_filename(&cover_filename)
             .with_filename(PODCAST_FILENAME)
             .with_direct_paths(direct_paths)
             .build(|directory| -> Result<String, CustomError> {


### PR DESCRIPTION
The download path and the "Re-apply filename and directory format" rescan both hardcoded the cover base name to `image`, so the cover-filename setting only ever took effect for the podcast's main cover on add. Both now go through `resolve_cover_filename`, so the configured name is used consistently on new downloads and when re-applying filenames.

Episode numbering in #2189 is a separate matter and not touched here: numbering only ever rewrites the embedded tag title (under the "Re-apply metadata" rescan option), never the on-disk filename. Filenames pick up a number via the `{episodeNumber}` token in the format template.

Fixes #2189
