### PR TITLE
test(e2e): cover the untested UI routes

### DIFF
--- a/ui/e2e/tests/pages.spec.ts
+++ b/ui/e2e/tests/pages.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test'
+
+// Coverage for the routes the other suites don't touch: the home dashboard,
+// the waiting list, the rescan/gpodder/mopidy settings tabs, tags, discover,
+// the profile page and the user-administration tables. The e2e server runs
+// without auth, which provisions a standard admin user, so the admin-only
+// pages render their real content here.
+
+test('home dashboard renders its episode rails', async ({ page }) => {
+    await page.goto('/ui/home/view')
+
+    await expect(page.getByRole('heading', { name: 'Recently listened' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Latest episodes' })).toBeVisible()
+})
+
+test('waiting list page renders its empty state', async ({ page }) => {
+    await page.goto('/ui/waiting-list')
+
+    await expect(page.getByRole('heading', { name: 'Waiting list' })).toBeVisible()
+    await expect(
+        page.getByText('Nothing queued yet. Pick episodes from your inbox.')
+    ).toBeVisible()
+})
+
+test('rescan settings can re-apply the filename format', async ({ page }) => {
+    await page.goto('/ui/settings/rescan')
+
+    const applyFilenames = page.getByText('Re-apply filename and directory format')
+    await expect(applyFilenames).toBeVisible()
+    await applyFilenames.click()
+
+    await page.getByRole('button', { name: 'Rescan audio files' }).click()
+    await expect(page.getByText('Rescan done')).toBeVisible()
+})
+
+test('tags can be created and deleted', async ({ page }) => {
+    await page.goto('/ui/tags')
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible()
+
+    await page.getByPlaceholder('Add tag').fill('E2E Coverage Tag')
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
+
+    // The new tag renders as an editable row; its input carries the name.
+    await expect(page.getByRole('textbox').last()).toHaveValue('E2E Coverage Tag')
+
+    // Clean up so later suites see no tags.
+    await page.getByRole('button', { name: 'Delete' }).click()
+    await expect(
+        page.getByText('No tags created yet. Use the form above to add one.')
+    ).toBeVisible()
+})
+
+test('gpodder settings render the available-podcasts table', async ({ page }) => {
+    await page.goto('/ui/settings/gpodder')
+
+    await expect(page.getByRole('columnheader', { name: 'Device' })).toBeVisible()
+})
+
+test('mopidy settings render the server list', async ({ page }) => {
+    await page.goto('/ui/settings/mopidy')
+
+    await expect(page.getByText('No Mopidy servers configured yet.')).toBeVisible()
+})
+
+test('discover page renders its tabs', async ({ page }) => {
+    await page.goto('/ui/discover')
+
+    await expect(page.getByRole('heading', { name: 'Discover' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'For you' })).toBeVisible()
+})
+
+test('profile page renders the account form', async ({ page }) => {
+    await page.goto('/ui/profile')
+
+    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible()
+    await expect(page.getByText('API key', { exact: true })).toBeVisible()
+})
+
+test('user administration lists users', async ({ page }) => {
+    await page.goto('/ui/administration/users')
+
+    await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible()
+})
+
+test('invites administration renders and offers a create action', async ({ page }) => {
+    await page.goto('/ui/administration/invites')
+
+    await expect(page.getByRole('columnheader', { name: 'Role' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Add new' })).toBeVisible()
+})

--- a/ui/e2e/tests/settings-coverage.spec.ts
+++ b/ui/e2e/tests/settings-coverage.spec.ts
@@ -1,0 +1,244 @@
+import { expect, test, type Page } from '@playwright/test'
+import { readSeed } from '../helpers'
+
+const seed = readSeed()
+const detailPage = `/ui/podcasts/${seed.podcastId}/episodes`
+
+// Exhaustive coverage of the labels and toggles on the settings surfaces:
+// the Data Retention page, the Naming page, the per-podcast settings modal
+// and the rescan tab. Toggle tests flip every switch, persist, reload and
+// assert, then restore the original state so later suites see pristine
+// settings.
+
+// --- Data Retention -------------------------------------------------------
+
+const RETENTION_LABELS = [
+    'Automatic cleanup',
+    'Days to keep',
+    'Automatically update podcasts',
+    'Automatically download new episodes',
+    'Episode numbering',
+    'Number of initial podcasts to download',
+    'Max parallel downloads',
+    'Transcode to Opus',
+    'Use one cover for all episodes',
+    'NFO format',
+    'Cover filename',
+]
+
+// Every Switcher on the Data Retention page, by input id.
+const RETENTION_TOGGLES = [
+    'auto-cleanup',
+    'auto-update',
+    'auto-download',
+    'episode-numbering',
+    'auto-transcode-opus',
+    'use-one-cover-for-all-episodes',
+]
+
+test('data retention page shows every label and control', async ({ page }) => {
+    await page.goto('/ui/settings/retention')
+
+    for (const label of RETENTION_LABELS) {
+        await expect(page.getByText(label, { exact: true })).toBeVisible()
+    }
+    await expect(page.getByRole('button', { name: 'Run cleanup now' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+
+    // The numeric inputs and the NFO select carry stable ids.
+    for (const id of [
+        'days-to-keep',
+        'number-of-podcasts-to-download',
+        'max-parallel-downloads',
+        'cover-filename',
+        'nfo-format',
+    ]) {
+        await expect(page.locator(`#${id}`)).toBeAttached()
+    }
+})
+
+test('every data retention toggle persists across a reload', async ({ page }) => {
+    await page.goto('/ui/settings/retention')
+
+    // The switch inputs are sr-only; wait for one label before reading state.
+    await expect(page.getByText('Automatic cleanup', { exact: true })).toBeVisible()
+
+    const initial: Record<string, boolean> = {}
+    for (const id of RETENTION_TOGGLES) {
+        initial[id] = await page.locator(`#${id}`).isChecked()
+    }
+
+    const flipAllAndSave = async () => {
+        for (const id of RETENTION_TOGGLES) {
+            // The input is sr-only; its wrapping div carries the click handler.
+            await page.locator(`#${id}`).locator('xpath=ancestor::div[1]').click()
+        }
+        await page.getByRole('button', { name: 'Save' }).click()
+        await expect(page.getByText('Settings saved')).toBeVisible()
+    }
+
+    await flipAllAndSave()
+    await page.reload()
+    for (const id of RETENTION_TOGGLES) {
+        expect(await page.locator(`#${id}`).isChecked(), `${id} after flip`).toBe(!initial[id])
+    }
+
+    // Restore the original state so later suites keep pristine settings.
+    await flipAllAndSave()
+    await page.reload()
+    for (const id of RETENTION_TOGGLES) {
+        expect(await page.locator(`#${id}`).isChecked(), `${id} restored`).toBe(initial[id])
+    }
+})
+
+// --- Naming ---------------------------------------------------------------
+
+const NAMING_LABELS = [
+    'Rename podcasts',
+    'Use existing filenames',
+    'Replace illegal characters in filenames with a dash',
+    'Colon replacement',
+    'Standard episode format',
+    'Sample episode format',
+    'Standard podcast format',
+    'Sample podcast format',
+    'Use direct paths',
+]
+
+const NAMING_CHECKBOXES = ['use-existing-filenames', 'replace-invalid-characters', 'directPaths']
+
+test('naming page shows every label and control', async ({ page }) => {
+    await page.goto('/ui/settings/naming')
+
+    for (const label of NAMING_LABELS) {
+        await expect(page.getByText(label, { exact: true })).toBeVisible()
+    }
+    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible()
+
+    for (const id of ['colon-replacement', 'episode-format', 'podcast-format']) {
+        await expect(page.locator(`#${id}`)).toBeAttached()
+    }
+})
+
+test('every naming checkbox persists across a reload', async ({ page }) => {
+    await page.goto('/ui/settings/naming')
+    await expect(page.getByText('Rename podcasts', { exact: true })).toBeVisible()
+
+    const initial: Record<string, boolean> = {}
+    for (const id of NAMING_CHECKBOXES) {
+        initial[id] = await page.locator(`#${id}`).isChecked()
+    }
+
+    const flipAllAndSave = async () => {
+        // CustomCheckbox (base-ui) exposes a role=checkbox button; the id sits
+        // on a hidden proxy input, so click the buttons by document order.
+        for (let i = 0; i < NAMING_CHECKBOXES.length; i++) {
+            await page.getByRole('checkbox').nth(i).click()
+        }
+        await page.getByRole('button', { name: 'Save' }).click()
+        await expect(page.getByText('Settings saved')).toBeVisible()
+    }
+
+    await flipAllAndSave()
+    await page.reload()
+    for (const id of NAMING_CHECKBOXES) {
+        expect(await page.locator(`#${id}`).isChecked(), `${id} after flip`).toBe(!initial[id])
+    }
+
+    await flipAllAndSave()
+    await page.reload()
+    for (const id of NAMING_CHECKBOXES) {
+        expect(await page.locator(`#${id}`).isChecked(), `${id} restored`).toBe(initial[id])
+    }
+})
+
+// --- Rescan ---------------------------------------------------------------
+
+test('rescan tab shows every option label', async ({ page }) => {
+    await page.goto('/ui/settings/rescan')
+
+    for (const label of [
+        'Re-apply filename and directory format',
+        'Transcode existing MP3 episodes to Opus',
+        'Drop per-episode covers',
+        'Refresh embedded tags',
+    ]) {
+        await expect(page.getByText(label, { exact: true })).toBeVisible()
+    }
+    await expect(page.getByRole('button', { name: 'Rescan audio files' })).toBeVisible()
+})
+
+// --- Per-podcast settings modal ------------------------------------------
+
+const openPodcastSettings = async (page: Page) => {
+    await page.goto(detailPage)
+    await page.locator('svg.lucide-settings').locator('xpath=ancestor::button[1]').click()
+    return page.getByRole('dialog')
+}
+
+test('podcast settings modal shows every label on the settings tab', async ({ page }) => {
+    const dialog = await openPodcastSettings(page)
+
+    await expect(dialog.getByText('Configure settings')).toBeVisible()
+    await expect(dialog.getByRole('tab', { name: 'Settings' })).toBeVisible()
+    await expect(dialog.getByRole('tab', { name: 'Batch actions' })).toBeVisible()
+
+    for (const label of [
+        'Episode numbering',
+        'Automatic cleanup',
+        'Days to keep',
+        'Automatically update podcasts',
+        'Automatically download new episodes',
+        'Auto-transcribe',
+        'Colon replacement',
+        'Use one cover for all episodes',
+        'NFO format',
+        'Cover filename',
+        'Number of initial podcasts to download',
+        'Activated',
+    ]) {
+        await expect(dialog.getByText(label, { exact: true })).toBeVisible()
+    }
+    await expect(dialog.getByRole('button', { name: 'Save' })).toBeVisible()
+})
+
+test('podcast settings modal shows every batch action', async ({ page }) => {
+    const dialog = await openPodcastSettings(page)
+    await dialog.getByRole('tab', { name: 'Batch actions' }).click()
+
+    for (const label of [
+        'Download missing episodes',
+        'Re-download missing files',
+        'Refresh local download state',
+        'Delete all downloaded files',
+    ]) {
+        await expect(dialog.getByText(label, { exact: true })).toBeVisible()
+    }
+    // Three "Run" buttons and one "Delete" button drive the actions.
+    await expect(dialog.getByRole('button', { name: 'Run' })).toHaveCount(3)
+    await expect(dialog.getByRole('button', { name: 'Delete', exact: true })).toBeVisible()
+})
+
+test('per-podcast episode-numbering toggle persists', async ({ page }) => {
+    const dialog = await openPodcastSettings(page)
+
+    // The per-podcast switches have no id; locate by the label's sibling.
+    const numbering = dialog
+        .locator('label', { hasText: 'Episode numbering' })
+        .locator('xpath=following-sibling::*[1]')
+    const before = await numbering.locator('input').isChecked()
+
+    await numbering.click()
+    await dialog.getByRole('button', { name: 'Save' }).click()
+
+    // Reopen and confirm the new value was stored server-side.
+    const reopened = await openPodcastSettings(page)
+    const after = reopened
+        .locator('label', { hasText: 'Episode numbering' })
+        .locator('xpath=following-sibling::*[1]')
+    await expect(after.locator('input')).toBeChecked({ checked: !before })
+
+    // Restore.
+    await after.click()
+    await reopened.getByRole('button', { name: 'Save' }).click()
+})

--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -59,6 +59,8 @@
   "max-parallel-downloads-explanation": "How many episodes are downloaded at the same time (minimum 1, default 3). Because Opus transcoding runs as part of each download, this also limits how many episodes are transcoded simultaneously — lower it on a slow CPU.",
   "use-one-cover-for-all-episodes": "Use one cover for all episodes",
   "use-one-cover-for-all-episodes-explanation": "When enabled, do not download a separate cover image for each episode. The shared podcast directory cover (image.jpg) will be used instead, saving disk space.",
+  "nfo-format": "NFO format",
+  "cover-filename": "Cover filename",
   "rescan-audio-files": "Rescan audio files",
   "rescan-audio-files-description": "PodFetch rescans all audio files to update chapter metadata. Optionally, re-apply the current settings to already-downloaded episodes by ticking the boxes below.",
   "rescan-option-applyFilenames": "Re-apply filename and directory format",


### PR DESCRIPTION
Expands e2e coverage of the UI.

**`pages.spec.ts`** — routes the existing specs didn't touch: home dashboard, waiting list, settings→rescan (runs a rescan + asserts the toast), tags (create+delete), gpodder, mopidy, discover, profile, and administration users/invites.

**`settings-coverage.spec.ts`** — exhaustive label + toggle coverage:
- Data Retention: every label/control asserted; every switch flipped → saved → reloaded → asserted → restored.
- Naming: every label/control asserted; all three checkboxes persistence-tested.
- Rescan: all four option labels.
- Per-podcast settings modal: every label on the Settings tab, every Batch-actions row, and per-podcast episode-numbering persistence.

**Bug fix found while covering labels:** the `nfo-format` and `cover-filename` i18n keys were missing from `en.json`, so both the Data Retention page and the per-podcast modal rendered the raw kebab keys as labels. Added the English strings ("NFO format", "Cover filename").

The e2e server runs without auth, which provisions a standard admin user, so the admin-only pages render real content. All tests pass locally.
