### PR TITLE
feat: tag aggregated rss items with their source podcast

### DIFF
--- a/crates/podfetch-web/src/controllers/websocket_controller.rs
+++ b/crates/podfetch-web/src/controllers/websocket_controller.rs
@@ -23,9 +23,9 @@ use rss::extension::itunes::{
 use rss::extension::{Extension, ExtensionBuilder};
 use rss::{
     Category, CategoryBuilder, Channel, ChannelBuilder, EnclosureBuilder, GuidBuilder, Item,
-    ItemBuilder,
+    ItemBuilder, SourceBuilder,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Namespace declared on generated channels so `<podcast:transcript>` items
 /// are valid Podcasting 2.0 markup.
@@ -99,7 +99,20 @@ pub async fn get_rss_feed(
         .summary(Some("Your local rss feed for your podcasts".to_string()))
         .build();
 
-    let items = get_podcast_items_rss(&state, &downloaded_episodes, &api_key, &server_url);
+    // Map every episode's podcast id to its show so each item can name its
+    // originating podcast in the aggregated feed (#2055).
+    let podcast_by_id: HashMap<String, Podcast> = PodcastService::get_all_podcasts_raw()?
+        .into_iter()
+        .map(|p| (p.id.clone(), p))
+        .collect();
+
+    let items = get_podcast_items_rss(
+        &state,
+        &downloaded_episodes,
+        &api_key,
+        &server_url,
+        Some(&podcast_by_id),
+    );
 
     let channel_builder = ChannelBuilder::default()
         .namespaces(podcast_namespace())
@@ -251,7 +264,9 @@ pub async fn get_rss_feed_for_podcast(
         .summary(podcast.summary.clone())
         .build();
 
-    let items = get_podcast_items_rss(&state, &downloaded_episodes, &api_key, &server_url);
+    // Per-podcast feed: the channel title already is the show name, so no
+    // per-item source is needed.
+    let items = get_podcast_items_rss(&state, &downloaded_episodes, &api_key, &server_url, None);
     let channel_builder = ChannelBuilder::default()
         .namespaces(podcast_namespace())
         .language(podcast.clone().language)
@@ -284,6 +299,7 @@ fn get_podcast_items_rss(
     downloaded_episodes: &[PodcastEpisodeDto],
     api_key: &Option<String>,
     server_url: &str,
+    podcast_by_id: Option<&HashMap<String, Podcast>>,
 ) -> Vec<Item> {
     downloaded_episodes
         .iter()
@@ -295,15 +311,32 @@ fn get_podcast_items_rss(
                 .mime_type(mime_type)
                 .build();
 
+            // In the aggregated feed every item shares the "Podfetch" channel,
+            // so readers can't tell which show an episode belongs to. Tag each
+            // item with its originating podcast via the standard RSS <source>
+            // element and the itunes author, without touching the title (#2055).
+            let podcast = podcast_by_id.and_then(|m| m.get(&episode.podcast_id));
+
             let itunes_extension = ITunesItemExtensionBuilder::default()
                 .duration(Some(episode.total_time.to_string()))
                 .image(Some(episode.local_image_url.to_string()))
+                .author(podcast.map(|p| p.name.clone()))
                 .build();
 
             let guid = GuidBuilder::default()
                 .permalink(false)
                 .value(&episode.episode_id)
                 .build();
+
+            let source = podcast.map(|p| {
+                SourceBuilder::default()
+                    .url(add_api_key_to_url(
+                        format!("{server_url}rss/{}", p.id),
+                        api_key,
+                    ))
+                    .title(Some(p.name.clone()))
+                    .build()
+            });
 
             let mut item = ItemBuilder::default()
                 .guid(Some(guid))
@@ -312,6 +345,7 @@ fn get_podcast_items_rss(
                 .description(Some(episode.description.to_string()))
                 .enclosure(Some(enclosure))
                 .itunes_ext(itunes_extension)
+                .source(source)
                 .build();
 
             attach_transcript_extensions(state, episode, api_key, server_url, &mut item);

--- a/ui/e2e/tests/app.spec.ts
+++ b/ui/e2e/tests/app.spec.ts
@@ -111,3 +111,14 @@ test('podcast settings modal exposes the per-podcast configuration', async ({ pa
     await expect(page.getByText('Automatically update podcasts')).toBeVisible()
     await expect(page.getByText('Auto-transcribe', { exact: true })).toBeVisible()
 })
+
+test('the aggregated rss feed names each item source podcast', async ({ page }) => {
+    // The shared channel is "Podfetch"; each item carries its originating show
+    // via <source> and itunes:author so readers can tell them apart (#2055).
+    const rss = await (await page.request.get('/rss')).text()
+
+    expect(rss).toContain('<source')
+    expect(rss).toContain('Transcript E2E Podcast')
+    expect(rss).toContain('<itunes:author>Transcript E2E Podcast</itunes:author>')
+    expect(rss).toContain(`rss/${seed.podcastId}`)
+})


### PR DESCRIPTION
Closes #2055.

The reporter uses the aggregated `/rss` feed as a single source of truth, but every item shares the `Podfetch` channel, so their RSS reader shows "Podfetch" as the feed for every episode and there's no way to tell which show an episode came from.

RSS 2.0 already has the right element for this: `<item><source url="...">Name</source>` means "the channel this item came from". Each item in the aggregated feed now carries:
- `<source url="{server_url}rss/{podcastId}">Podcast name</source>`
- `<itunes:author>Podcast name</itunes:author>`

The item **title is left untouched** (no title-stuffing), and per-podcast feeds (`/rss/{id}`) are unchanged since their channel title already is the show name. Readers that understand `<source>`/`itunes:author` can now group or label by show; readers that ignore them are unaffected.

e2e: added a test asserting the aggregated feed carries `<source>` + `itunes:author` for the seeded podcast.
