### PR TITLE
test(e2e): make the podfetch launcher work on Windows/Git Bash

### DIFF
--- a/ui/e2e/servers/start-podfetch.sh
+++ b/ui/e2e/servers/start-podfetch.sh
@@ -22,7 +22,14 @@ mkdir -p "$RUN_DIR/static"
 cp -R "$ROOT/ui/dist/." "$RUN_DIR/static/"
 
 cd "$RUN_DIR"
-export DATABASE_URL="sqlite://$RUN_DIR/podcast.db"
+# diesel's multi-connection URL parser rejects the `sqlite://<abs-path>` form
+# for Windows-style paths (the drive letter trips it up), so on Git Bash /
+# MSYS use a bare relative path (we already cd'd into RUN_DIR). Linux/macOS
+# keep the original scheme form, so CI is unaffected.
+case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) export DATABASE_URL="podcast.db" ;;
+    *) export DATABASE_URL="sqlite://$RUN_DIR/podcast.db" ;;
+esac
 export SERVER_URL="http://127.0.0.1:8000"
 export TRANSCRIPTION_API_BASE_URL="http://127.0.0.1:9998"
 


### PR DESCRIPTION
The Playwright e2e launcher hard-coded `DATABASE_URL="sqlite://$RUN_DIR/podcast.db"`. diesel's multi-connection URL parser rejects that `sqlite://<abs-path>` form for Windows-style paths (the drive letter trips it up), so the server panicked on startup and the whole suite was unrunnable under Git Bash/MSYS.

Detect the shell OS and use a bare relative `DATABASE_URL` on Windows (the script already `cd`s into `RUN_DIR`); Linux/macOS keep the original `sqlite://` scheme form, so **CI behavior is byte-identical**. Verified locally: the suite now boots and runs on Windows without any manual patching.