### PR TITLE
feat: give rss items a real link instead of the bare guid

### DIFF
--- a/crates/podfetch-web/src/controllers/websocket_controller.rs
+++ b/crates/podfetch-web/src/controllers/websocket_controller.rs
@@ -343,6 +343,12 @@ fn get_podcast_items_rss(
                 .pub_date(Some(episode.date_of_recording.to_string()))
                 .title(Some(episode.name.to_string()))
                 .description(Some(episode.description.to_string()))
+                // Without a <link> readers fall back to showing the opaque guid;
+                // point it at the episode's page in the podfetch UI (#2055).
+                .link(Some(format!(
+                    "{server_url}ui/podcasts/{}/episodes",
+                    episode.podcast_id
+                )))
                 .enclosure(Some(enclosure))
                 .itunes_ext(itunes_extension)
                 .source(source)

--- a/ui/e2e/tests/app.spec.ts
+++ b/ui/e2e/tests/app.spec.ts
@@ -121,4 +121,7 @@ test('the aggregated rss feed names each item source podcast', async ({ page }) 
     expect(rss).toContain('Transcript E2E Podcast')
     expect(rss).toContain('<itunes:author>Transcript E2E Podcast</itunes:author>')
     expect(rss).toContain(`rss/${seed.podcastId}`)
+    // Each item links to its episode page in the UI instead of a bare guid.
+    expect(rss).toContain(`<link>`)
+    expect(rss).toContain(`ui/podcasts/${seed.podcastId}/episodes`)
 })


### PR DESCRIPTION
Follow-up to #2055 (the reporter's side question). RSS `<item>`s had no `<link>`, so readers like elfeed displayed the opaque episode guid (`4de55c72-…`) as the link, which goes nowhere. Each item now links to its episode page in the podfetch UI (`{server_url}ui/podcasts/{podcastId}/episodes`). Applies to both the aggregated and per-podcast feeds.

e2e: extended the aggregated-feed test to assert the `<link>` points at the UI episode page.