### PR TITLE
fix(i18n): replace leftover German string in English translation

### DIFF
--- a/ui/src/language/json/en.json
+++ b/ui/src/language/json/en.json
@@ -83,7 +83,7 @@
   "free-disk": "Available disk",
   "chapters": "Chapters",
   "title": "Title",
-  "timeslot": "Zeitfenster",
+  "timeslot": "Timeslot",
   "start-time": "Start time",
   "end-time": "End time",
   "system-info": "System information",


### PR DESCRIPTION
The English locale renders the `timeslot` key as Zeitfenster, a leftover from the German translation.

```json
timeslot: Zeitfenster,
```

Changed to Timeslot. The other locales already translate this key correctly.