### PR TITLE
fix(ui): keep IME composition alive in text inputs

### DIFF
--- a/ui/src/components/CustomInput.tsx
+++ b/ui/src/components/CustomInput.tsx
@@ -1,15 +1,35 @@
-import {ChangeEventHandler, FC, InputHTMLAttributes} from 'react'
+import {FC, InputHTMLAttributes, useEffect, useRef, useState} from 'react'
 import {LoadingSkeletonSpan} from "./ui/LoadingSkeletonSpan";
 
 
 export const CustomInput: FC<InputHTMLAttributes<HTMLInputElement> &  {
     loading?: boolean
 }> = ({ autoComplete, onBlur, className = '', id, name, onChange, disabled, placeholder, required, type = 'text', value, ...props }) => {
+    // Some callers keep the value in an external store (e.g. the react-query
+    // cache via setQueryData) that only notifies subscribers asynchronously.
+    // React then reverts the DOM value right after each input event, which
+    // cancels an active IME composition — Chinese/Japanese/Korean typing
+    // becomes unusable. Mirroring the value locally keeps the DOM update
+    // synchronous; external changes are applied while no composition runs.
+    const [localValue, setLocalValue] = useState(value)
+    const isComposing = useRef(false)
+
+    useEffect(() => {
+        if (!isComposing.current) {
+            setLocalValue(value)
+        }
+    }, [value])
+
     if (props.loading) {
         return <LoadingSkeletonSpan height="30px" width="100px" text={""} loading={props.loading}/>
     }
     return (
         <input onBlur={onBlur} autoComplete={autoComplete} disabled={disabled} className={"ui-input-surface" +
-            " px-4 py-2 rounded-lg text-sm ui-input-text placeholder:ui-input-text-disabled " + className} id={id} name={name} placeholder={placeholder} onChange={onChange} value={value} type={type} required={required} {...props} />
+            " px-4 py-2 rounded-lg text-sm ui-input-text placeholder:ui-input-text-disabled " + className} id={id} name={name} placeholder={placeholder} onChange={(e) => {
+                setLocalValue(e.target.value)
+                onChange?.(e)
+            }} value={localValue ?? ''} type={type} required={required} {...props}
+            onCompositionStart={() => { isComposing.current = true }}
+            onCompositionEnd={() => { isComposing.current = false }} />
     )
 }

--- a/ui/src/components/CustomInput.tsx
+++ b/ui/src/components/CustomInput.tsx
@@ -4,32 +4,61 @@ import {LoadingSkeletonSpan} from "./ui/LoadingSkeletonSpan";
 
 export const CustomInput: FC<InputHTMLAttributes<HTMLInputElement> &  {
     loading?: boolean
-}> = ({ autoComplete, onBlur, className = '', id, name, onChange, disabled, placeholder, required, type = 'text', value, ...props }) => {
-    // Some callers keep the value in an external store (e.g. the react-query
-    // cache via setQueryData) that only notifies subscribers asynchronously.
-    // React then reverts the DOM value right after each input event, which
-    // cancels an active IME composition — Chinese/Japanese/Korean typing
-    // becomes unusable. Mirroring the value locally keeps the DOM update
-    // synchronous; external changes are applied while no composition runs.
+}> = ({ autoComplete, onBlur, onCompositionEnd, onCompositionStart, className = '', id, name, onChange, disabled, loading, placeholder, required, type = 'text', value, ...props }) => {
     const [localValue, setLocalValue] = useState(value)
+    const localValueRef = useRef(value)
     const isComposing = useRef(false)
+    const inputSequence = useRef(0)
+    const pendingExternalValue = useRef<{ value: typeof value, inputSequence: number } | null>(null)
 
     useEffect(() => {
-        if (!isComposing.current) {
-            setLocalValue(value)
+        if (isComposing.current) {
+            pendingExternalValue.current = {value, inputSequence: inputSequence.current}
+            return
         }
+
+        localValueRef.current = value
+        setLocalValue(value)
     }, [value])
 
-    if (props.loading) {
-        return <LoadingSkeletonSpan height="30px" width="100px" text={""} loading={props.loading}/>
+    if (loading) {
+        return <LoadingSkeletonSpan height="30px" width="100px" text={""} loading={loading}/>
     }
+
     return (
         <input onBlur={onBlur} autoComplete={autoComplete} disabled={disabled} className={"ui-input-surface" +
             " px-4 py-2 rounded-lg text-sm ui-input-text placeholder:ui-input-text-disabled " + className} id={id} name={name} placeholder={placeholder} onChange={(e) => {
+                inputSequence.current += 1
+                localValueRef.current = e.target.value
                 setLocalValue(e.target.value)
                 onChange?.(e)
             }} value={localValue ?? ''} type={type} required={required} {...props}
-            onCompositionStart={() => { isComposing.current = true }}
-            onCompositionEnd={() => { isComposing.current = false }} />
+            onCompositionStart={(e) => {
+                isComposing.current = true
+                pendingExternalValue.current = null
+                onCompositionStart?.(e)
+            }}
+            onCompositionEnd={(e) => {
+                isComposing.current = false
+                onCompositionEnd?.(e)
+
+                // React may deliver the final input event immediately after
+                // compositionend. Reconcile a genuine external update in a
+                // microtask, but never overwrite that final user input with
+                // an older cache echo.
+                const pending = pendingExternalValue.current
+                if (pending) {
+                    queueMicrotask(() => {
+                        if (inputSequence.current !== pending.inputSequence || isComposing.current) {
+                            return
+                        }
+                        if (!Object.is(pending.value, localValueRef.current)) {
+                            localValueRef.current = pending.value
+                            setLocalValue(pending.value)
+                        }
+                        pendingExternalValue.current = null
+                    })
+                }
+            }} />
     )
 }

--- a/ui/src/components/PodcastCard.tsx
+++ b/ui/src/components/PodcastCard.tsx
@@ -228,7 +228,8 @@ export const PodcastCard: FC<PodcastCardProps> = ({podcast}) => {
                                     setNewTag(event.target.value)
                                 }}
                                 onKeyDown={(event) => {
-                                    if (event.key === 'Enter') {
+                                    // Enter also confirms an IME composition — don't treat that as submit
+                                    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
                                         createAndAssignTag()
                                     }
                                 }}

--- a/ui/src/pages/TagsPage.tsx
+++ b/ui/src/pages/TagsPage.tsx
@@ -215,7 +215,8 @@ export const TagsPage = ()=>{
                     onChange={(event) => setNewTagName(event.target.value)}
                     placeholder={t('tag-add-placeholder') as string}
                     onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
+                        // Enter also confirms an IME composition — don't treat that as submit
+                        if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
                             createTag()
                         }
                     }}
@@ -260,7 +261,7 @@ export const TagsPage = ()=>{
                                     value={draft.name}
                                     onChange={(event) => updateTagDraft(tag.id, {name: event.target.value})}
                                     onKeyDown={(event) => {
-                                        if (event.key === 'Enter' && !saveDisabled) {
+                                        if (event.key === 'Enter' && !event.nativeEvent.isComposing && !saveDisabled) {
                                             saveTag(tag)
                                         }
                                     }}


### PR DESCRIPTION
## Problem

Typing with a composition-based input method (Chinese Zhuyin/Pinyin, Japanese, Korean) is unusable in several text fields — most visibly the search box on the podcasts page and the fields on the settings page. Every keystroke closes the IME candidate window and the composed text ends up corrupted: composing 你好 produces `nni你h`.

## Root cause

Some inputs keep their controlled `value` in an external store — the react-query cache via `queryClient.setQueryData` (`Podcasts.tsx`, `SettingsData.tsx`). TanStack Query notifies subscribers asynchronously, so no synchronous re-render happens while the input event is being processed. React then restores the DOM value back to the stale prop, and Chromium cancels the active IME composition on that programmatic write.

I verified this against a production build, driving a real composition through CDP `Input.imeSetComposition`. Before the fix each keystroke produced two programmatic value writes (revert + reapply) and a cancelled composition:

```
compositionstart, compositionupdate:n,  input:n  -> value=n
compositionstart, compositionupdate:ni, input:ni -> value=nni     <- composition restarted
```

After the fix there are zero programmatic writes and a single composition runs to completion:

```
compositionstart, compositionupdate:n, compositionupdate:ni, compositionupdate:你, compositionend -> value=你
```

## Fix

- `CustomInput` mirrors the controlled value in local state, so the DOM value updates synchronously within the input event. External value changes are still applied whenever no composition is running, guarded by `compositionstart`/`compositionend`. This covers every current and future caller without touching call sites.
- Guard the Enter-to-submit handlers on the tag inputs (`TagsPage`, `PodcastCard`) with `KeyboardEvent.isComposing`, so pressing Enter to accept an IME candidate no longer creates or saves a tag prematurely.

## Testing

- `tsc --noEmit` and a production `vite build` pass.
- Simulated IME composition against the production bundle: the composition survives across keystrokes, debounced searches and cache echoes, and the committed text is correct.
- Regression-checked plain (non-IME) typing: the value still propagates and the debounced search fires with the typed filter.